### PR TITLE
feat: add beating shapes visual effect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
 
     <!-- Unified Visual Effects (replaces DynamicBackground and VibratingStrings) -->
     <div class="relative isolate" v-if="!isLoading">
+      <BeatingShapes class="z-[-1]" />
       <UnifiedVisualEffects class="z-0" />
       <FloatingPopup class="z-2" />
     </div>
@@ -41,6 +42,7 @@ import { useAppLoading } from "@/composables/useAppLoading";
 import LoadingSplash from "@/components/LoadingSplash.vue";
 import FloatingPopup from "@/components/FloatingPopup.vue";
 import UnifiedVisualEffects from "@/components/UnifiedVisualEffects.vue";
+import BeatingShapes from "@/components/BeatingShapes.vue";
 import AppHeader from "@/components/AppHeader.vue";
 import ConfigPanel from "@/components/ConfigPanel.vue";
 import InstrumentSelector from "@/components/InstrumentSelector.vue";

--- a/src/__tests__/stores/visualConfig.test.ts
+++ b/src/__tests__/stores/visualConfig.test.ts
@@ -29,6 +29,7 @@ describe('Visual Config Store', () => {
       expect(visualConfigStore.config.ambient.isEnabled).toBe(true)
       expect(visualConfigStore.config.particles.isEnabled).toBe(true)
       expect(visualConfigStore.config.strings.isEnabled).toBe(true)
+      expect(visualConfigStore.config.beatingShapes.isEnabled).toBe(true)
       expect(visualConfigStore.visualsEnabled).toBe(true)
       expect(visualConfigStore.savedConfigs).toEqual([])
       expect(visualConfigStore.isLoading).toBe(false)

--- a/src/components/BeatingShapes.vue
+++ b/src/components/BeatingShapes.vue
@@ -1,0 +1,214 @@
+<template>
+  <div v-if="config.isEnabled" class="beating-shapes" :style="rootStyle">
+    <div
+      v-for="i in config.count"
+      :key="i"
+      class="shape-set"
+      :style="getSetStyle(i)"
+    >
+      <div v-if="config.commonBeat" class="dancer shape square common-beat" />
+      <div v-if="config.quarterBeat" class="dancer shape line quarter-beat" />
+      <div v-if="config.thirdBeat" class="dancer shape triangle third-beat" />
+      <div v-if="config.halfBeat" class="dancer shape rectangle half-beat" />
+      <div v-if="config.doubleBeat" class="dancer shape circle double-beat" />
+      <div v-if="config.tripleBeat" class="dancer shape hexagon triple-beat" />
+      <div
+        v-if="config.quadrupleBeat"
+        class="dancer shape octagon quadruple-beat"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useSequencerStore } from "@/stores/sequencer";
+import { useVisualConfigStore } from "@/stores/visualConfig";
+
+const sequencerStore = useSequencerStore();
+const visualConfigStore = useVisualConfigStore();
+
+const config = computed(() => visualConfigStore.config.beatingShapes);
+const tempo = computed(() => sequencerStore.config.tempo);
+
+const rootStyle = computed(() => ({
+  "--bpm": tempo.value,
+  "--base-scale": config.value.scale,
+}));
+
+function getSetStyle(i: number) {
+  const offset = (i - 1) * 5;
+  return {
+    transform: `translate(${offset}%, ${offset}%)`,
+  };
+}
+</script>
+
+<style scoped>
+.beating-shapes {
+  position: fixed;
+  inset: 0;
+  z-index: -10;
+  overflow: hidden;
+  pointer-events: none;
+  --bpm: 120;
+  --common-time-beat: calc(60s / var(--bpm));
+  --quarter-time-beat: calc(var(--common-time-beat) * 4);
+  --third-time-beat: calc(var(--common-time-beat) * 3);
+  --half-time-beat: calc(var(--common-time-beat) * 2);
+  --double-time-beat: calc(var(--common-time-beat) / 2);
+  --triple-time-beat: calc(var(--common-time-beat) / 3);
+  --quadruple-time-beat: calc(var(--common-time-beat) / 4);
+  --hue: 80;
+  --color: hsla(var(--hue), 100%, 60%, 1);
+  --highlight: hsla(calc(var(--hue) + 180), 100%, 60%, 1);
+  --accent: hsla(calc(var(--hue) - 60), 100%, 60%, 1);
+  animation: 0s calc(var(--common-time-beat) * 4) shiftColors infinite forwards;
+}
+
+.dancer {
+  animation: var(--beat-time) var(--action, beat) infinite forwards;
+}
+
+.shape-set {
+  position: absolute;
+  inset: 0;
+}
+
+.shape {
+  background: black;
+  position: absolute;
+  scale: var(--base-scale, 1);
+}
+
+.rotate {
+  --action: rotate;
+}
+
+.line {
+  width: 50vmax;
+  height: 1px;
+  rotate: 40deg;
+  top: 20%;
+  --action: rotate;
+}
+
+.rectangle {
+  width: 50vw;
+  height: 50px;
+  rotate: -100deg;
+  bottom: 50%;
+  right: 1%;
+  --action: rotate;
+}
+
+.triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  width: 10vw;
+  top: -5%;
+  left: 50%;
+  aspect-ratio: 1;
+  rotate: 20deg;
+  --action: rotate;
+}
+
+.square {
+  bottom: -10%;
+  left: -5%;
+  rotate: 45deg;
+  width: 70vmin;
+  aspect-ratio: 1;
+}
+
+.hexagon {
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  bottom: -10%;
+  right: -5%;
+  width: 30vmax;
+  aspect-ratio: 1;
+  --action: rotate;
+}
+
+.octagon {
+  clip-path: polygon(30% 0%, 70% 0%, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0% 70%, 0% 30%);
+  top: 10%;
+  left: 5%;
+  width: 5vmax;
+  aspect-ratio: 1;
+}
+
+.circle {
+  border-radius: 50%;
+  right: -5%;
+  top: -5%;
+  width: 20vmax;
+  aspect-ratio: 1;
+}
+
+.common-beat {
+  --beat-time: var(--common-time-beat);
+}
+
+.quarter-beat {
+  --beat-time: var(--quarter-time-beat);
+}
+
+.third-beat {
+  --beat-time: var(--third-time-beat);
+}
+
+
+.half-beat {
+  --beat-time: var(--half-time-beat);
+}
+
+.double-beat {
+  --beat-time: var(--double-time-beat);
+}
+
+.triple-beat {
+  --beat-time: var(--triple-time-beat);
+}
+
+.quadruple-beat {
+  --beat-time: var(--quadruple-time-beat);
+}
+
+@keyframes beat {
+  0% {
+    scale: 0.8;
+  }
+  14% {
+    scale: 1.1;
+    box-shadow: -5px -5px var(--color), -10px -10px var(--accent);
+  }
+  96% {
+    scale: 1;
+  }
+  100% {
+    scale: 0.8;
+  }
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(-5deg);
+  }
+  14% {
+    transform: rotate(3deg);
+    box-shadow: -5px -5px var(--color), -10px -10px var(--highlight);
+  }
+  96% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(10deg);
+  }
+}
+
+@keyframes shiftColors {
+  100% {
+    --hue: calc(var(--hue) + 36);
+  }
+}
+</style>

--- a/src/composables/useVisualConfig.ts
+++ b/src/composables/useVisualConfig.ts
@@ -12,6 +12,7 @@ import type {
   PaletteConfig,
   FloatingPopupConfig,
   HilbertScopeConfig,
+  BeatingShapesConfig,
   VisualEffectsConfig,
 } from "@/types/visual";
 
@@ -32,6 +33,7 @@ export type {
   PaletteConfig,
   FloatingPopupConfig,
   HilbertScopeConfig,
+  BeatingShapesConfig,
   VisualEffectsConfig,
 };
 
@@ -54,6 +56,7 @@ export function useVisualConfig() {
   const paletteConfig = computed(() => store.config.palette);
   const floatingPopupConfig = computed(() => store.config.floatingPopup);
   const hilbertScopeConfig = computed(() => store.config.hilbertScope);
+  const beatingShapesConfig = computed(() => store.config.beatingShapes);
 
   return {
     // Configuration state
@@ -71,6 +74,7 @@ export function useVisualConfig() {
     paletteConfig,
     floatingPopupConfig,
     hilbertScopeConfig,
+    beatingShapesConfig,
 
     // Methods from store
     updateConfig: store.updateConfig,

--- a/src/data/visual-config-metadata.ts
+++ b/src/data/visual-config-metadata.ts
@@ -569,6 +569,61 @@ export const UNIFIED_CONFIG = {
     },
   },
 
+  beatingShapes: {
+    _meta: {
+      label: "Beating Shapes",
+      icon: "🔷",
+      description: "Geometric shapes that pulse with the beat",
+    },
+    isEnabled: {
+      value: true,
+      label: "Enable Beating Shapes",
+    },
+    count: {
+      value: 1,
+      min: 1,
+      max: 10,
+      step: 1,
+      label: "Shape Sets",
+    },
+    scale: {
+      value: 1,
+      min: 0.5,
+      max: 2,
+      step: 0.1,
+      label: "Scale",
+      format: (v: number) => `${(v * 100).toFixed(0)}%`,
+    },
+    commonBeat: {
+      value: true,
+      label: "Common Beat",
+    },
+    halfBeat: {
+      value: true,
+      label: "Half Beat",
+    },
+    quarterBeat: {
+      value: true,
+      label: "Quarter Beat",
+    },
+    thirdBeat: {
+      value: false,
+      label: "Third Beat",
+    },
+    doubleBeat: {
+      value: true,
+      label: "Double Beat",
+    },
+    tripleBeat: {
+      value: false,
+      label: "Triple Beat",
+    },
+    quadrupleBeat: {
+      value: true,
+      label: "Quadruple Beat",
+    },
+  },
+
   hilbertScope: {
     _meta: {
       label: "Hilbert Scope",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   DynamicColorConfig,
   PaletteConfig,
   FloatingPopupConfig,
+  BeatingShapesConfig,
 } from "./visual";
 
 // Canvas and Animation Types

--- a/src/types/visual.ts
+++ b/src/types/visual.ts
@@ -100,6 +100,32 @@ export interface FloatingPopupConfig {
 }
 
 /**
+ * Beating Shapes visual effect configuration
+ */
+export interface BeatingShapesConfig {
+  /** Whether beating shapes are enabled */
+  isEnabled: boolean;
+  /** Number of shape sets */
+  count: number;
+  /** Base scale for shapes */
+  scale: number;
+  /** Enable common beat duration */
+  commonBeat: boolean;
+  /** Enable half beat duration */
+  halfBeat: boolean;
+  /** Enable quarter beat duration */
+  quarterBeat: boolean;
+  /** Enable third beat duration */
+  thirdBeat: boolean;
+  /** Enable double beat duration */
+  doubleBeat: boolean;
+  /** Enable triple beat duration */
+  tripleBeat: boolean;
+  /** Enable quadruple beat duration */
+  quadrupleBeat: boolean;
+}
+
+/**
  * Frequency to value mapping configuration
  */
 export interface FrequencyMapping {
@@ -446,4 +472,6 @@ export interface VisualEffectsConfig {
   floatingPopup: FloatingPopupConfig;
   /** Hilbert Scope configuration */
   hilbertScope: HilbertScopeConfig;
+  /** Beating shapes configuration */
+  beatingShapes: BeatingShapesConfig;
 }


### PR DESCRIPTION
## Summary
- add BeatingShapes component that animates geometric shapes to sequencer tempo
- extend visual config system and types with beatingShapes controls
- mount BeatingShapes behind UnifiedVisualEffects

## Testing
- `npm test` *(fails: Test Files 35 failed | 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b162760832784f6cd294ca64cd6