### PR TITLE
Add interval-driven support for 14 Tonal-backed modes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "emotitone-solfege",
       "dependencies": {
+        "@strudel/codemirror": "^1.3.0",
         "@strudel/soundfonts": "^1.3.0",
         "@strudel/web": "^1.3.0",
         "@tonaljs/tonal": "^4.10.0",
@@ -230,6 +231,22 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.2", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/search": ["@codemirror/search@6.6.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.40.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@5.0.2", "", {}, "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
@@ -326,6 +343,18 @@
 
     "@kabelsalat/web": ["@kabelsalat/web@0.4.1", "", { "dependencies": { "@kabelsalat/core": "0.4.0", "@kabelsalat/lib": "0.4.1" } }, "sha512-ASkFhePJLx3GjadYOueI7sHKXBbRPk/a1pfslFeQNI9gU7yZq/KrnkmOmLrgrtixAsy7gyi1vWqkmRRvH3Ki6w=="],
 
+    "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.8", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@nanostores/persistent": ["@nanostores/persistent@0.10.2", "", { "peerDependencies": { "nanostores": "^0.9.0 || ^0.10.0 || ^0.11.0" } }, "sha512-BEndnLhRC+yP7gXTESepBbSj8XNl8OXK9hu4xAgKC7MWJHKXnEqJMqY47LUyHxK6vYgFnisyHmqq+vq8AUFyIg=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -335,6 +364,12 @@
     "@one-ini/wasm": ["@one-ini/wasm@0.1.1", "", {}, "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@replit/codemirror-emacs": ["@replit/codemirror-emacs@6.1.0", "", { "peerDependencies": { "@codemirror/autocomplete": "^6.0.2", "@codemirror/commands": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.1", "@codemirror/view": "^6.3.0" } }, "sha512-74DITnht6Cs6sHg02PQ169IKb1XgtyhI9sLD0JeOFco6Ds18PT+dkD8+DgXBDokne9UIFKsBbKPnpFRAz60/Lw=="],
+
+    "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
+
+    "@replit/codemirror-vscode-keymap": ["@replit/codemirror-vscode-keymap@6.0.2", "", { "peerDependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
 
@@ -385,6 +420,8 @@
     "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.45.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.45.1", "", { "os": "win32", "cpu": "x64" }, "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA=="],
+
+    "@strudel/codemirror": ["@strudel/codemirror@1.3.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.18.4", "@codemirror/commands": "^6.8.0", "@codemirror/lang-javascript": "^6.2.2", "@codemirror/language": "^6.10.8", "@codemirror/search": "^6.5.8", "@codemirror/state": "^6.5.1", "@codemirror/view": "^6.36.2", "@lezer/highlight": "^1.2.1", "@nanostores/persistent": "^0.10.2", "@replit/codemirror-emacs": "^6.1.0", "@replit/codemirror-vim": "^6.3.0", "@replit/codemirror-vscode-keymap": "^6.0.2", "@strudel/core": "1.2.6", "@strudel/draw": "1.2.6", "@strudel/tonal": "1.2.6", "@strudel/transpiler": "1.2.6", "@tonaljs/tonal": "^4.10.0", "nanostores": "^0.11.3", "superdough": "1.3.0" } }, "sha512-Bv6TkmaCtyjbPY/G9r214vQq4VyAp4ZQuTQS60zjlp2YXbYJX4H7piM+roOEqczR4lqE4yYxfdg83jEubY+1zA=="],
 
     "@strudel/core": ["@strudel/core@1.2.6", "", { "dependencies": { "@kabelsalat/web": "^0.4.1", "fraction.js": "^5.2.1" } }, "sha512-FA5Kxv3U+UhNRLIeuEpXck2o2J5AjHZbkAdSAK9Q2N3Az1G9Vnc+bXXfgDFyY3yRH9mXXQvTerz8jr876pGGng=="],
 
@@ -647,6 +684,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "core-js-compat": ["core-js-compat@3.45.0", "", { "dependencies": { "browserslist": "^4.25.1" } }, "sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1256,6 +1295,8 @@
 
     "strip-literal": ["strip-literal@3.0.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
 
     "superdough": ["superdough@1.3.0", "", { "dependencies": { "@kabelsalat/lib": "^0.4.1", "nanostores": "^0.11.3" } }, "sha512-LhmsrErcv9EMFNb79+3tvn6h7WgzKp4yRe1XtT2+eRY9oEpV4Jz0nb9Dxil3OLaNhQ6V2FuwPWBLQJb2aVtwuQ=="],
@@ -1369,6 +1410,8 @@
     "vue-template-compiler": ["vue-template-compiler@2.7.16", "", { "dependencies": { "de-indent": "^1.0.2", "he": "^1.2.0" } }, "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ=="],
 
     "vue-tsc": ["vue-tsc@1.8.27", "", { "dependencies": { "@volar/typescript": "~1.11.1", "@vue/language-core": "1.8.27", "semver": "^7.5.4" }, "peerDependencies": { "typescript": "*" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 

--- a/src/__tests__/composables/useColorSystem.test.ts
+++ b/src/__tests__/composables/useColorSystem.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+
+  return {
+    ...actual,
+    onUnmounted: vi.fn(),
+  };
+});
+
+import { ref } from "vue";
+
+Object.defineProperty(globalThis, "requestAnimationFrame", {
+  configurable: true,
+  writable: true,
+  value: vi.fn(() => 1),
+});
+Object.defineProperty(globalThis, "cancelAnimationFrame", {
+  configurable: true,
+  writable: true,
+  value: vi.fn(),
+});
+
+vi.unmock("@/data");
+
+const dynamicColorConfig = ref({
+  isEnabled: true,
+  chromaticMapping: false,
+  hueAnimationAmplitude: 15,
+  animationSpeed: 1,
+  saturation: 0.8,
+  baseLightness: 0.5,
+  lightnessRange: 0.7,
+});
+
+vi.mock("@/composables/useVisualConfig", () => ({
+  useVisualConfig: () => ({
+    dynamicColorConfig,
+  }),
+}));
+
+import { useColorSystem } from "@/composables/useColorSystem";
+
+describe("useColorSystem", () => {
+  it("rotates dynamic hues by key and degree count", () => {
+    dynamicColorConfig.value.chromaticMapping = false;
+    const colorSystem = useColorSystem();
+
+    const cMajorDo = colorSystem.getStaticPrimaryColorByScaleIndex(
+      0,
+      "major",
+      "C",
+      3
+    );
+    const dMajorDo = colorSystem.getStaticPrimaryColorByScaleIndex(
+      0,
+      "major",
+      "D",
+      3
+    );
+    const cPentatonicLa = colorSystem.getStaticPrimaryColorByScaleIndex(
+      4,
+      "major pentatonic",
+      "C",
+      3
+    );
+    const cMajorTi = colorSystem.getStaticPrimaryColorByScaleIndex(
+      6,
+      "major",
+      "C",
+      3
+    );
+
+    expect(cMajorDo).not.toBe(dMajorDo);
+    expect(cPentatonicLa).not.toBe(cMajorTi);
+  });
+
+  it("uses static pitch-class colors when chromatic mapping is enabled", () => {
+    dynamicColorConfig.value.chromaticMapping = true;
+    const colorSystem = useColorSystem();
+
+    const minorBluesSe = colorSystem.getStaticPrimaryColorByScaleIndex(
+      3,
+      "minor blues",
+      "C",
+      3
+    );
+    const chromaticFs = colorSystem.getStaticPrimaryColorByScaleIndex(
+      6,
+      "chromatic",
+      "C",
+      3
+    );
+
+    expect(minorBluesSe).toBe(chromaticFs);
+  });
+
+  it("resolves altered syllables without falling back to the default error color", () => {
+    dynamicColorConfig.value.chromaticMapping = false;
+    const colorSystem = useColorSystem();
+
+    const fi = colorSystem.getStaticPrimaryColor("Fi", "lydian", 3, "C");
+    const se = colorSystem.getStaticPrimaryColor("Se", "minor blues", 3, "C");
+
+    expect(fi).not.toBe("hsla(0, 80%, 50%, 1)");
+    expect(se).not.toBe("hsla(0, 80%, 50%, 1)");
+  });
+});

--- a/src/__tests__/composables/useKeyboardControls.test.ts
+++ b/src/__tests__/composables/useKeyboardControls.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+
+  return {
+    ...actual,
+    onMounted: (callback: () => void) => callback(),
+    onUnmounted: vi.fn(),
+  };
+});
+
+import { reactive, ref } from "vue";
+import { useKeyboardControls } from "@/composables/useKeyboardControls";
+
+const mockMusicStore = reactive({
+  currentScale: reactive({ degreeCount: 12 }),
+  attackNoteWithOctave: vi.fn().mockResolvedValue("mock-note-id"),
+  releaseNote: vi.fn(),
+});
+
+const mockPatternsStore = {
+  removeLastFromCurrentSketch: vi.fn(),
+};
+
+vi.mock("@/stores/music", () => ({
+  useMusicStore: () => mockMusicStore,
+}));
+
+vi.mock("@/stores/patterns", () => ({
+  usePatternsStore: () => mockPatternsStore,
+}));
+
+describe("useKeyboardControls", () => {
+  beforeEach(() => {
+    mockMusicStore.currentScale.degreeCount = 12;
+    mockMusicStore.attackNoteWithOctave.mockClear();
+    mockMusicStore.releaseNote.mockClear();
+    mockPatternsStore.removeLastFromCurrentSketch.mockClear();
+  });
+
+  it("builds three full 12-key rows for chromatic parity", () => {
+    const controls = useKeyboardControls(ref(4));
+    const mapping = controls.getKeyboardMapping();
+
+    expect(Object.keys(mapping)).toHaveLength(36);
+    expect(mapping.Digit1).toEqual({
+      solfegeIndex: 0,
+      octave: 5,
+      label: "1",
+    });
+    expect(mapping.KeyQ).toEqual({
+      solfegeIndex: 0,
+      octave: 4,
+      label: "Q",
+    });
+    expect(mapping.Backslash).toEqual({
+      solfegeIndex: 11,
+      octave: 3,
+      label: "\\",
+    });
+  });
+
+  it("uses the leftmost keys for smaller mode sizes", () => {
+    mockMusicStore.currentScale.degreeCount = 5;
+    const controls = useKeyboardControls(ref(4));
+    const mapping = controls.getKeyboardMapping();
+
+    expect(Object.keys(mapping)).toHaveLength(15);
+    expect(mapping.Digit5.solfegeIndex).toBe(4);
+    expect(mapping.KeyT.solfegeIndex).toBe(4);
+    expect(mapping.KeyG.solfegeIndex).toBe(4);
+    expect(mapping.Digit6).toBeUndefined();
+  });
+
+  it("returns display labels for mapped notes", () => {
+    mockMusicStore.currentScale.degreeCount = 12;
+    const controls = useKeyboardControls(ref(4));
+
+    expect(controls.getKeyboardLetterForNote(11, 3)).toBe("\\");
+    expect(controls.getKeyboardLetterForNote(0, 4)).toBe("Q");
+  });
+});

--- a/src/__tests__/services/music.test.ts
+++ b/src/__tests__/services/music.test.ts
@@ -1,507 +1,156 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { MusicTheoryService } from '@/services/music'
-import { CHROMATIC_NOTES, MAJOR_SCALE, MINOR_SCALE } from '@/data'
-import type { ChromaticNote, MusicalMode, MelodyCategory } from '@/types/music'
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock melody data - must be declared before the mock
-const mockIntervalPatterns = [
-  {
-    name: 'Perfect Fifth',
-    description: 'A perfect fifth interval',
-    emotion: 'stable',
-    sequence: [
-      { note: 'Do', duration: '4n' },
-      { note: 'Sol', duration: '4n' }
-    ],
-    intervals: [7],
-  },
-  {
-    name: 'Major Third',
-    description: 'A major third interval',
-    emotion: 'happy',
-    sequence: [
-      { note: 'Do', duration: '4n' },
-      { note: 'Mi', duration: '4n' }
-    ],
-    intervals: [4],
-  },
-]
+vi.unmock("@/services/music");
+vi.unmock("@/data");
 
-const mockPatternMelodies = [
-  {
-    name: 'Scale Run',
-    description: 'Ascending scale pattern',
-    emotion: 'energetic',
-    sequence: [
-      { note: 'Do', duration: '8n' },
-      { note: 'Re', duration: '8n' },
-      { note: 'Mi', duration: '8n' },
-      { note: 'Fa', duration: '8n' },
-      { note: 'Sol', duration: '8n' },
-    ],
-  },
-]
+import { MODE_DEFINITIONS, MODE_ORDER, getScaleForMode } from "@/data";
+import { MusicTheoryService } from "@/services/music";
+import type { MusicalMode } from "@/types/music";
 
-const mockCompleteMelodies = [
-  {
-    name: 'Twinkle Twinkle',
-    description: 'Classic children\'s song',
-    emotion: 'playful',
-    sequence: [
-      { note: 'Do', duration: '4n' },
-      { note: 'Do', duration: '4n' },
-      { note: 'Sol', duration: '4n' },
-      { note: 'Sol', duration: '4n' },
-    ],
-    defaultBpm: 120,
-    defaultKey: 'C',
-  },
-]
-
-const mockMelodicPatterns = [
-  ...mockIntervalPatterns,
-  ...mockPatternMelodies,
-  ...mockCompleteMelodies,
-]
-
-// Mock the data imports
-vi.mock('@/data', async () => {
-  const actual = await vi.importActual('@/data')
-  return {
-    ...actual,
-    getAllMelodicPatterns: vi.fn(() => mockMelodicPatterns),
-    getPatternsByEmotion: vi.fn(() => mockMelodicPatterns.filter(p => p.emotion?.includes('happy'))),
-    getIntervalPatterns: vi.fn(() => mockIntervalPatterns),
-    getMelodicPatterns: vi.fn(() => mockPatternMelodies),
-    getCompleteMelodies: vi.fn(() => mockCompleteMelodies),
-  }
-})
-
-// Mock Tonal.js
-vi.mock('@tonaljs/tonal', () => ({
-  Note: {
-    get: vi.fn((note: string) => {
-      const noteMap: Record<string, { freq?: number; pc?: string }> = {
-        'C4': { freq: 261.63, pc: 'C' },
-        'C#4': { freq: 277.18, pc: 'C#' },
-        'D4': { freq: 293.66, pc: 'D' },
-        'D#4': { freq: 311.13, pc: 'D#' },
-        'E4': { freq: 329.63, pc: 'E' },
-        'F4': { freq: 349.23, pc: 'F' },
-        'F#4': { freq: 369.99, pc: 'F#' },
-        'G4': { freq: 392.00, pc: 'G' },
-        'G#4': { freq: 415.30, pc: 'G#' },
-        'A4': { freq: 440.00, pc: 'A' },
-        'A#4': { freq: 466.16, pc: 'A#' },
-        'B4': { freq: 493.88, pc: 'B' },
-        'C5': { freq: 523.25, pc: 'C' },
-        'Db4': { freq: 277.18, pc: 'Db' },
-        'Eb4': { freq: 311.13, pc: 'Eb' },
-        'Gb4': { freq: 369.99, pc: 'Gb' },
-        'Ab4': { freq: 415.30, pc: 'Ab' },
-        'Bb4': { freq: 466.16, pc: 'Bb' },
-      }
-      return noteMap[note] || { freq: undefined, pc: undefined }
-    }),
-  },
-  Scale: {
-    get: vi.fn((scaleName: string) => {
-      const scaleMap: Record<string, { notes: string[] }> = {
-        'C major': { notes: ['C', 'D', 'E', 'F', 'G', 'A', 'B'] },
-        'C minor': { notes: ['C', 'D', 'Eb', 'F', 'G', 'Ab', 'Bb'] },
-        'D major': { notes: ['D', 'E', 'F#', 'G', 'A', 'B', 'C#'] },
-        'D minor': { notes: ['D', 'E', 'F', 'G', 'A', 'Bb', 'C'] },
-        'E major': { notes: ['E', 'F#', 'G#', 'A', 'B', 'C#', 'D#'] },
-        'F# major': { notes: ['F#', 'G#', 'A#', 'B', 'C#', 'D#', 'E#'] },
-        'Gb major': { notes: ['Gb', 'Ab', 'Bb', 'Cb', 'Db', 'Eb', 'F'] },
-      }
-      return scaleMap[scaleName] || { notes: [] }
-    }),
-  },
-}))
-
-describe('MusicTheoryService', () => {
-  let musicService: MusicTheoryService
+describe("MusicTheoryService", () => {
+  let musicService: MusicTheoryService;
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    musicService = new MusicTheoryService()
-  })
+    musicService = new MusicTheoryService();
+  });
 
-  describe('Constructor and Initialization', () => {
-    it('should initialize with default values', () => {
-      expect(musicService.getCurrentKey()).toBe('C')
-      expect(musicService.getCurrentMode()).toBe('major')
-      expect(musicService.getCurrentScale()).toBe(MAJOR_SCALE)
-    })
+  it("supports the full curated 14-mode catalog", () => {
+    expect(MODE_ORDER).toHaveLength(14);
 
-    it('should initialize melody cache', () => {
-      const allMelodies = musicService.getAllMelodies()
-      expect(allMelodies.length).toBeGreaterThan(0)
-      expect(allMelodies.every(m => m.category)).toBe(true)
-    })
+    for (const mode of MODE_ORDER) {
+      musicService.setCurrentMode(mode);
+      const scale = musicService.getCurrentScale();
+      const definition = MODE_DEFINITIONS[mode];
 
-    it('should categorize melodies correctly', () => {
-      const intervals = musicService.getMelodiesByCategory('intervals')
-      const patterns = musicService.getMelodiesByCategory('patterns')
-      const complete = musicService.getMelodiesByCategory('complete')
-
-      expect(intervals.every(m => m.category === 'intervals')).toBe(true)
-      expect(patterns.every(m => m.category === 'patterns')).toBe(true)
-      expect(complete.every(m => m.category === 'complete')).toBe(true)
-    })
-  })
-
-  describe('Key and Mode Management', () => {
-    it('should set and get current key', () => {
-      musicService.setCurrentKey('D')
-      expect(musicService.getCurrentKey()).toBe('D')
-    })
-
-    it('should throw error for invalid key', () => {
-      expect(() => musicService.setCurrentKey('Invalid' as ChromaticNote)).toThrow('Invalid key: Invalid')
-    })
-
-    it('should set and get current mode', () => {
-      musicService.setCurrentMode('minor')
-      expect(musicService.getCurrentMode()).toBe('minor')
-    })
-
-    it('should return correct scale for mode', () => {
-      expect(musicService.getCurrentScale()).toBe(MAJOR_SCALE)
-      
-      musicService.setCurrentMode('minor')
-      expect(musicService.getCurrentScale()).toBe(MINOR_SCALE)
-    })
-  })
-
-  describe('Scale Notes Calculation', () => {
-    it('should return correct scale notes for C major', () => {
-      const notes = musicService.getCurrentScaleNotes()
-      expect(notes).toEqual(['C', 'D', 'E', 'F', 'G', 'A', 'B'])
-    })
-
-    it('should return correct scale notes for C minor', () => {
-      musicService.setCurrentMode('minor')
-      const notes = musicService.getCurrentScaleNotes()
-      expect(notes).toEqual(['C', 'D', 'D#', 'F', 'G', 'G#', 'A#'])
-    })
-
-    it('should return correct scale notes for D major', () => {
-      musicService.setCurrentKey('D')
-      const notes = musicService.getCurrentScaleNotes()
-      expect(notes).toEqual(['D', 'E', 'F#', 'G', 'A', 'B', 'C#'])
-    })
-
-    it('should normalize flat notes to sharp notes', () => {
-      musicService.setCurrentKey('D')
-      musicService.setCurrentMode('minor')
-      const notes = musicService.getCurrentScaleNotes()
-      
-      // Should convert any flats to sharps
-      expect(notes.every(note => !note.includes('b'))).toBe(true)
-    })
-
-    it('should handle edge cases in note normalization', () => {
-      // Test with key that produces edge case notes
-      musicService.setCurrentKey('F#')
-      const notes = musicService.getCurrentScaleNotes()
-      
-      expect(notes).toContain('F#')
-      expect(notes.length).toBe(7)
-    })
-  })
-
-  describe('Frequency Calculation', () => {
-    it('should calculate correct frequency for scale degrees', () => {
-      const doFreq = musicService.getNoteFrequency(0, 4) // Do in C major
-      expect(doFreq).toBe(261.63)
-
-      const miFreq = musicService.getNoteFrequency(2, 4) // Mi in C major
-      expect(miFreq).toBe(329.63)
-    })
-
-    it('should calculate correct frequency for octave note (Do\')', () => {
-      const doOctaveFreq = musicService.getNoteFrequency(7, 4) // Do' (octave)
-      expect(doOctaveFreq).toBe(523.25) // C5
-    })
-
-    it('should handle different octaves', () => {
-      const doFreq3 = musicService.getNoteFrequency(0, 3) // Do in octave 3
-      const doFreq5 = musicService.getNoteFrequency(0, 5) // Do in octave 5
-      
-      expect(doFreq5).toBeGreaterThan(doFreq3)
-    })
-
-    it('should calculate correct octave for ascending scale', () => {
-      musicService.setCurrentKey('B')
-      const doFreq = musicService.getNoteFrequency(0, 4) // B4
-      const reFreq = musicService.getNoteFrequency(1, 4) // C#5 (next octave)
-      
-      expect(reFreq).toBeGreaterThan(doFreq)
-    })
-
-    it('should fallback to manual calculation if Tonal.js fails', () => {
-      // Mock Tonal.js to return no frequency
-      vi.mocked(require('@tonaljs/tonal').Note.get).mockReturnValue({ freq: undefined })
-      
-      const freq = musicService.getNoteFrequency(0, 4)
-      expect(freq).toBeGreaterThan(0)
-      expect(freq).toBeCloseTo(261.63, 1)
-    })
-  })
-
-  describe('Note Name Calculation', () => {
-    it('should return correct note names for scale degrees', () => {
-      expect(musicService.getNoteName(0, 4)).toBe('C4') // Do
-      expect(musicService.getNoteName(2, 4)).toBe('E4') // Mi
-      expect(musicService.getNoteName(4, 4)).toBe('G4') // Sol
-    })
-
-    it('should return correct note name for octave note', () => {
-      expect(musicService.getNoteName(7, 4)).toBe('C5') // Do'
-    })
-
-    it('should handle different keys', () => {
-      musicService.setCurrentKey('G')
-      expect(musicService.getNoteName(0, 4)).toBe('G4') // Do in G major
-      expect(musicService.getNoteName(2, 4)).toBe('B4') // Mi in G major
-    })
-
-    it('should handle octave wrapping correctly', () => {
-      musicService.setCurrentKey('B')
-      const doName = musicService.getNoteName(0, 4) // B4
-      const reName = musicService.getNoteName(1, 4) // Should be C#5
-      
-      expect(doName).toBe('B4')
-      expect(reName).toBe('C#5')
-    })
-  })
-
-  describe('Solfege Data', () => {
-    it('should return correct solfege data for scale degrees', () => {
-      const doData = musicService.getSolfegeData(0)
-      expect(doData).toBeDefined()
-      expect(doData?.name).toBe('Do')
-      expect(doData?.number).toBe(1)
-
-      const miData = musicService.getSolfegeData(2)
-      expect(miData).toBeDefined()
-      expect(miData?.name).toBe('Mi')
-      expect(miData?.number).toBe(3)
-    })
-
-    it('should return null for invalid scale degrees', () => {
-      const invalidData = musicService.getSolfegeData(10)
-      expect(invalidData).toBeNull()
-    })
-
-    it('should return different solfege data for different modes', () => {
-      const majorData = musicService.getSolfegeData(2)
-      
-      musicService.setCurrentMode('minor')
-      const minorData = musicService.getSolfegeData(2)
-      
-      expect(majorData?.name).toBe('Mi')
-      expect(minorData?.name).toBe('Me')
-    })
-  })
-
-  describe('Melody Management', () => {
-    it('should return all melodies', () => {
-      const allMelodies = musicService.getAllMelodies()
-      expect(allMelodies.length).toBe(mockMelodicPatterns.length)
-      expect(allMelodies.every(m => m.category)).toBe(true)
-    })
-
-    it('should return melodies by category', () => {
-      const intervals = musicService.getMelodiesByCategory('intervals')
-      const patterns = musicService.getMelodiesByCategory('patterns')
-      const complete = musicService.getMelodiesByCategory('complete')
-
-      expect(intervals.length).toBe(mockIntervalPatterns.length)
-      expect(patterns.length).toBe(mockPatternMelodies.length)
-      expect(complete.length).toBe(mockCompleteMelodies.length)
-    })
-
-    it('should return melodies by emotion', () => {
-      const happyMelodies = musicService.getMelodiesByEmotion('happy')
-      expect(happyMelodies.length).toBeGreaterThan(0)
-      expect(happyMelodies.every(m => m.emotion?.toLowerCase().includes('happy'))).toBe(true)
-    })
-
-    it('should search melodies by text', () => {
-      const twinkleResults = musicService.searchMelodies('twinkle')
-      expect(twinkleResults.length).toBeGreaterThan(0)
-      expect(twinkleResults.some(m => m.name.toLowerCase().includes('twinkle'))).toBe(true)
-
-      const playfulResults = musicService.searchMelodies('playful')
-      expect(playfulResults.length).toBeGreaterThan(0)
-      expect(playfulResults.some(m => m.emotion?.toLowerCase().includes('playful'))).toBe(true)
-    })
-
-    it('should search melodies case-insensitively', () => {
-      const upperResults = musicService.searchMelodies('TWINKLE')
-      const lowerResults = musicService.searchMelodies('twinkle')
-      
-      expect(upperResults.length).toBe(lowerResults.length)
-    })
-
-    it('should return empty array for non-existent category', () => {
-      const nonExistentCategory = musicService.getMelodiesByCategory('nonexistent' as MelodyCategory)
-      expect(nonExistentCategory).toEqual([])
-    })
-  })
-
-  describe('User Melody Management', () => {
-    const mockUserMelody = {
-      name: 'My Custom Melody',
-      description: 'A user-created melody',
-      emotion: 'creative',
-      sequence: [
-        { note: 'Do', duration: '4n' },
-        { note: 'Re', duration: '4n' },
-        { note: 'Mi', duration: '4n' },
-      ],
+      expect(scale.mode).toBe(mode);
+      expect(scale.name).toBe(definition.label);
+      expect(scale.degreeCount).toBe(definition.degreeCount);
+      expect(scale.intervalNames).toHaveLength(definition.degreeCount);
+      expect(scale.solfege).toHaveLength(definition.degreeCount);
     }
+  });
 
-    it('should add user melody', () => {
-      const addedMelody = musicService.addUserMelody(mockUserMelody)
-      
-      expect(addedMelody.category).toBe('userCreated')
-      expect(addedMelody.name).toBe(mockUserMelody.name)
-      
-      const userMelodies = musicService.getMelodiesByCategory('userCreated')
-      expect(userMelodies).toContain(addedMelody)
-      
-      const allMelodies = musicService.getAllMelodies()
-      expect(allMelodies).toContain(addedMelody)
-    })
+  it("generates movable-do labels from intervals for representative modes", () => {
+    expect(getScaleForMode("major").solfege.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Mi",
+      "Fa",
+      "Sol",
+      "La",
+      "Ti",
+    ]);
 
-    it('should remove user melody', () => {
-      const addedMelody = musicService.addUserMelody(mockUserMelody)
-      
-      musicService.removeUserMelody(addedMelody.name)
-      
-      const userMelodies = musicService.getMelodiesByCategory('userCreated')
-      expect(userMelodies.find(m => m.name === addedMelody.name)).toBeUndefined()
-      
-      const allMelodies = musicService.getAllMelodies()
-      expect(allMelodies.find(m => m.name === addedMelody.name)).toBeUndefined()
-    })
+    expect(getScaleForMode("minor").solfege.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Me",
+      "Fa",
+      "Sol",
+      "Le",
+      "Te",
+    ]);
 
-    it('should not affect other categories when removing user melody', () => {
-      const originalIntervalsCount = musicService.getMelodiesByCategory('intervals').length
-      
-      musicService.addUserMelody(mockUserMelody)
-      musicService.removeUserMelody(mockUserMelody.name)
-      
-      const finalIntervalsCount = musicService.getMelodiesByCategory('intervals').length
-      expect(finalIntervalsCount).toBe(originalIntervalsCount)
-    })
-  })
+    expect(getScaleForMode("lydian").solfege.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Mi",
+      "Fi",
+      "Sol",
+      "La",
+      "Ti",
+    ]);
 
-  describe('Legacy Methods', () => {
-    it('should return all melodic patterns', () => {
-      const patterns = musicService.getMelodicPatterns()
-      expect(patterns.length).toBe(mockMelodicPatterns.length)
-    })
+    expect(
+      getScaleForMode("minor blues").solfege.map((note) => note.name)
+    ).toEqual(["Do", "Me", "Fa", "Se", "Sol", "Te"]);
 
-    it('should return melodic patterns by category', () => {
-      const intervals = musicService.getMelodicPatternsByCategory('intervals')
-      const patterns = musicService.getMelodicPatternsByCategory('patterns')
-      
-      expect(intervals.length).toBeGreaterThan(0)
-      expect(patterns.length).toBeGreaterThan(0)
-    })
+    expect(
+      getScaleForMode("chromatic").solfege.map((note) => note.name)
+    ).toEqual([
+      "Do",
+      "Ra",
+      "Re",
+      "Me",
+      "Mi",
+      "Fa",
+      "Se",
+      "Sol",
+      "Le",
+      "La",
+      "Te",
+      "Ti",
+    ]);
+  });
 
-    it('should filter intervals correctly', () => {
-      const intervals = musicService.getMelodicPatternsByCategory('intervals')
-      
-      // All intervals should have exactly one interval in their intervals array
-      expect(intervals.every(pattern => 
-        pattern.intervals && pattern.intervals.length === 1
-      )).toBe(true)
-    })
+  it("normalizes current scale notes without forcing seven degrees", () => {
+    musicService.setCurrentKey("C");
 
-    it('should filter patterns correctly', () => {
-      const patterns = musicService.getMelodicPatternsByCategory('patterns')
-      
-      // All patterns should either have no intervals or more than one interval
-      expect(patterns.every(pattern => 
-        !pattern.intervals || pattern.intervals.length !== 1
-      )).toBe(true)
-    })
-  })
+    musicService.setCurrentMode("minor");
+    expect(musicService.getCurrentScaleNotes()).toEqual([
+      "C",
+      "D",
+      "D#",
+      "F",
+      "G",
+      "G#",
+      "A#",
+    ]);
 
-  describe('Error Handling', () => {
-    it('should handle Tonal.js errors gracefully', () => {
-      vi.mocked(require('@tonaljs/tonal').Scale.get).mockImplementation(() => {
-        throw new Error('Tonal.js error')
-      })
-      
-      expect(() => musicService.getCurrentScaleNotes()).toThrow()
-    })
+    musicService.setCurrentMode("major pentatonic");
+    expect(musicService.getCurrentScaleNotes()).toEqual([
+      "C",
+      "D",
+      "E",
+      "G",
+      "A",
+    ]);
 
-    it('should handle invalid note conversion', () => {
-      vi.mocked(require('@tonaljs/tonal').Note.get).mockReturnValue({ freq: undefined, pc: undefined })
-      
-      // Should fallback to manual calculation
-      const freq = musicService.getNoteFrequency(0, 4)
-      expect(freq).toBeGreaterThan(0)
-    })
+    musicService.setCurrentMode("chromatic");
+    expect(musicService.getCurrentScaleNotes()).toEqual([
+      "C",
+      "C#",
+      "D",
+      "D#",
+      "E",
+      "F",
+      "F#",
+      "G",
+      "G#",
+      "A",
+      "A#",
+      "B",
+    ]);
+  });
 
-    it('should handle empty scale from Tonal.js', () => {
-      vi.mocked(require('@tonaljs/tonal').Scale.get).mockReturnValue({ notes: [] })
-      
-      expect(() => musicService.getCurrentScaleNotes()).toThrow()
-    })
-  })
+  it("maps chromatic notes to exact or deterministic fallback scale degrees", () => {
+    musicService.setCurrentKey("C");
+    musicService.setCurrentMode("major");
+    expect(musicService.getScaleIndexForChromaticNote("C#")).toBe(0);
+    expect(musicService.getScaleIndexForChromaticNote("B")).toBe(6);
 
-  describe('Note Normalization', () => {
-    it('should normalize flat notes to sharp equivalents', () => {
-      // Test direct normalization through the private method via public interface
-      musicService.setCurrentKey('D')
-      musicService.setCurrentMode('minor')
-      
-      const notes = musicService.getCurrentScaleNotes()
-      // Should contain sharp notes, not flat notes
-      expect(notes).not.toContain('Bb')
-      expect(notes).toContain('A#')
-    })
+    musicService.setCurrentMode("major pentatonic");
+    expect(musicService.getScaleIndexForChromaticNote("F")).toBe(2);
+    expect(musicService.getScaleIndexForChromaticNote("A#")).toBe(4);
 
-    it('should handle double accidentals', () => {
-      // Mock a scale that might produce double accidentals
-      vi.mocked(require('@tonaljs/tonal').Scale.get).mockReturnValue({
-        notes: ['F##', 'C##', 'Gbb', 'Dbb']
-      })
-      
-      const notes = musicService.getCurrentScaleNotes()
-      expect(notes).toContain('G') // F## -> G
-      expect(notes).toContain('D') // C## -> D
-      expect(notes).toContain('F') // Gbb -> F
-      expect(notes).toContain('C') // Dbb -> C
-    })
+    musicService.setCurrentMode("chromatic");
+    expect(musicService.getScaleIndexForChromaticNote("F#")).toBe(6);
+  });
 
-    it('should handle edge case enharmonic equivalents', () => {
-      vi.mocked(require('@tonaljs/tonal').Scale.get).mockReturnValue({
-        notes: ['E#', 'B#', 'Fb', 'Cb']
-      })
-      
-      const notes = musicService.getCurrentScaleNotes()
-      expect(notes).toContain('F')  // E# -> F
-      expect(notes).toContain('C')  // B# -> C
-      expect(notes).toContain('E')  // Fb -> E
-      expect(notes).toContain('B')  // Cb -> B
-    })
+  it("handles octave rollover using the actual degree count", () => {
+    const assertions: Array<[MusicalMode, number]> = [
+      ["major", 7],
+      ["major pentatonic", 5],
+      ["minor blues", 6],
+      ["chromatic", 12],
+    ];
 
-    it('should throw error for truly invalid notes', () => {
-      vi.mocked(require('@tonaljs/tonal').Scale.get).mockReturnValue({
-        notes: ['InvalidNote']
-      })
-      vi.mocked(require('@tonaljs/tonal').Note.get).mockReturnValue({ pc: undefined })
-      
-      expect(() => musicService.getCurrentScaleNotes()).toThrow()
-    })
-  })
-})
+    for (const [mode, degreeCount] of assertions) {
+      musicService.setCurrentMode(mode);
+      expect(musicService.getNoteName(degreeCount, 4)).toBe("C5");
+      expect(musicService.getNoteFrequency(degreeCount, 4)).toBeGreaterThan(
+        musicService.getNoteFrequency(0, 4)
+      );
+    }
+  });
+});

--- a/src/__tests__/stores/music.test.ts
+++ b/src/__tests__/stores/music.test.ts
@@ -1,334 +1,167 @@
-import { setActivePinia, createPinia } from 'pinia'
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { useMusicStore } from '@/stores/music'
-import { useInstrumentStore } from '@/stores/instrument'
-import { createTestPinia } from '../helpers/test-utils'
-import { resetAudioMocks } from '../helpers/audio-mocks'
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
 
+vi.unmock("@/services/music");
+vi.unmock("@/data");
 
-describe('Music Store', () => {
-  let musicStore: ReturnType<typeof useMusicStore>
-  let instrumentStore: ReturnType<typeof useInstrumentStore>
+import { useMusicStore } from "@/stores/music";
 
+const superdoughMocks = vi.hoisted(() => ({
+  attackNote: vi.fn().mockResolvedValue(undefined),
+  releaseNote: vi.fn(),
+  releaseAll: vi.fn(),
+  playNoteWithDuration: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/superdoughAudio", () => ({
+  attackNote: superdoughMocks.attackNote,
+  releaseNote: superdoughMocks.releaseNote,
+  releaseAll: superdoughMocks.releaseAll,
+  playNoteWithDuration: superdoughMocks.playNoteWithDuration,
+  initSuperdoughAudio: vi.fn().mockResolvedValue(undefined),
+  isPrewarmed: vi.fn().mockReturnValue(true),
+  prewarmSoundSamples: vi.fn().mockResolvedValue(undefined),
+  getAudioContext: vi.fn(),
+  emotitoneStrudelOutput: vi.fn(),
+  stopStrudelVisuals: vi.fn(),
+}));
+
+describe("music store", () => {
   beforeEach(() => {
-    setActivePinia(createTestPinia())
-    musicStore = useMusicStore()
-    instrumentStore = useInstrumentStore()
-    resetAudioMocks()
-    vi.clearAllMocks()
-  })
+    setActivePinia(createPinia());
+    superdoughMocks.attackNote.mockClear();
+    superdoughMocks.releaseNote.mockClear();
+    superdoughMocks.releaseAll.mockClear();
+    superdoughMocks.playNoteWithDuration.mockClear();
+    if (typeof localStorage?.clear === "function") {
+      localStorage.clear();
+    }
+  });
 
-  afterEach(() => {
-    vi.clearAllTimers?.()
-  })
+  it("exposes expanded mode metadata through computed state", () => {
+    const musicStore = useMusicStore();
 
-  describe('State Management', () => {
-    it('should initialize with default values', () => {
-      expect(musicStore.currentKey).toBe('C')
-      expect(musicStore.currentMode).toBe('major')
-      expect(musicStore.currentNote).toBe(null)
-      expect(musicStore.activeNotes.size).toBe(0)
-      expect(musicStore.isPlaying).toBe(false)
-      expect(musicStore.sequence).toEqual([])
-    })
+    musicStore.setKey("D");
+    musicStore.setMode("harmonic minor");
 
-    it('should allow setting key and mode', () => {
-      musicStore.setKey('D')
-      expect(musicStore.currentKey).toBe('D')
+    expect(musicStore.currentModeDefinition.label).toBe("Harmonic Minor");
+    expect(musicStore.currentKeyDisplay).toBe("D Harmonic Minor");
+    expect(musicStore.currentScale.degreeCount).toBe(7);
+    expect(musicStore.currentScale.solfege.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Me",
+      "Fa",
+      "Sol",
+      "Le",
+      "Ti",
+    ]);
+  });
 
-      musicStore.setMode('minor')
-      expect(musicStore.currentMode).toBe('minor')
-    })
-  })
+  it("tracks dynamic scale notes for non-heptatonic modes", () => {
+    const musicStore = useMusicStore();
 
-  describe('Computed Properties', () => {
-    it('should compute current scale', () => {
-      const scale = musicStore.currentScale
-      expect(scale.name).toBe('Major')
-      expect(scale.solfege).toHaveLength(7)
-    })
+    musicStore.setMode("major pentatonic");
+    expect(musicStore.currentScale.degreeCount).toBe(5);
+    expect(musicStore.currentScaleNotes).toEqual(["C", "D", "E", "G", "A"]);
+    expect(musicStore.solfegeData.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Mi",
+      "Sol",
+      "La",
+    ]);
+  });
 
-    it('should compute current scale notes', () => {
-      const notes = musicStore.currentScaleNotes
-      expect(notes).toEqual(['C', 'D', 'E', 'F', 'G', 'A', 'B'])
-    })
+  it("refreshes scale structure after mode changes even if the initial scale was already read", () => {
+    const musicStore = useMusicStore();
 
-    it('should compute solfege data', () => {
-      const solfege = musicStore.solfegeData
-      expect(solfege).toHaveLength(7)
-      expect(solfege[0].name).toBe('Do')
-    })
+    expect(musicStore.currentScale.degreeCount).toBe(7);
+    expect(musicStore.solfegeData.map((note) => note.name)).toEqual([
+      "Do",
+      "Re",
+      "Mi",
+      "Fa",
+      "Sol",
+      "La",
+      "Ti",
+    ]);
 
-    it('should compute current key display', () => {
-      expect(musicStore.currentKeyDisplay).toBe('C Major')
-      
-      musicStore.setKey('D')
-      musicStore.setMode('minor')
-      expect(musicStore.currentKeyDisplay).toBe('D Minor')
-    })
-  })
+    musicStore.setMode("minor blues");
 
-  describe('Note Playing', () => {
-    it('should play note with solfege index', async () => {
-      await musicStore.playNote(0) // Do
-      
-      expect(musicStore.currentNote).toBe('Do')
-      expect(musicStore.isPlaying).toBe(true)
-      expect(window.dispatchEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'note-played',
-          detail: expect.objectContaining({
-            note: expect.objectContaining({ name: 'Do' }),
-            frequency: expect.any(Number),
-            noteName: 'C4',
-            solfegeIndex: 0,
-            octave: 4
-          })
-        })
-      )
-    })
+    expect(musicStore.currentScale.degreeCount).toBe(6);
+    expect(musicStore.solfegeData.map((note) => note.name)).toEqual([
+      "Do",
+      "Me",
+      "Fa",
+      "Se",
+      "Sol",
+      "Te",
+    ]);
+  });
 
-    it('should play note with chromatic note string', async () => {
-      await musicStore.playNote('C4')
-      
-      expect(musicStore.currentNote).toBe('Do')
-      expect(musicStore.isPlaying).toBe(true)
-    })
+  it("parses chromatic note input using deterministic fallback for sparse modes", () => {
+    const musicStore = useMusicStore();
 
-    it('should attack and release notes', async () => {
-      const noteId = await musicStore.attackNote(0)
-      expect(noteId).toBe('mock-note-id')
-      expect(musicStore.activeNotes.size).toBe(1)
-      expect(musicStore.isPlaying).toBe(true)
+    musicStore.setMode("major pentatonic");
+    expect(musicStore.parseNoteInput("F4")).toEqual({
+      solfegeIndex: 2,
+      octave: 4,
+    });
 
-      musicStore.releaseNote(noteId!)
-      expect(musicStore.activeNotes.size).toBe(0)
-      expect(musicStore.isPlaying).toBe(false)
-    })
+    musicStore.setMode("chromatic");
+    expect(musicStore.parseNoteInput("F#4")).toEqual({
+      solfegeIndex: 6,
+      octave: 4,
+    });
+  });
 
-    it('should play note with duration', async () => {
-      const noteId = await musicStore.playNoteWithDuration(0, 4, '4n')
-      expect(noteId).toBe('mock-note-id')
-      expect(window.dispatchEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'note-played',
-          detail: expect.objectContaining({
-            duration: '4n',
-            octave: 4
-          })
-        })
-      )
-    })
+  it("plays notes using the actual current mode degree count", async () => {
+    const musicStore = useMusicStore();
+    const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
 
-    it('should handle multiple active notes', async () => {
-      const noteId1 = await musicStore.attackNote(0)
-      const noteId2 = await musicStore.attackNote(2)
-      
-      expect(musicStore.activeNotes.size).toBe(2)
-      expect(musicStore.getActiveNotes()).toHaveLength(2)
-      expect(musicStore.getActiveNoteNames()).toEqual(['C4', 'E4'])
-    })
+    musicStore.setKey("F#");
+    musicStore.setMode("chromatic");
+    const noteId = await musicStore.attackNote(11, 4);
 
-    it('should release all notes', async () => {
-      await musicStore.attackNote(0)
-      await musicStore.attackNote(2)
-      
-      expect(musicStore.activeNotes.size).toBe(2)
-      
-      musicStore.releaseAllNotes()
-      expect(musicStore.activeNotes.size).toBe(0)
-      expect(musicStore.isPlaying).toBe(false)
-    })
-  })
+    expect(noteId).toBe("F5_11_4");
+    expect(superdoughMocks.attackNote).toHaveBeenCalledWith(
+      "F5_11_4",
+      "F5",
+      "piano"
+    );
+    expect(musicStore.getActiveNotes()).toHaveLength(1);
+    expect(musicStore.getActiveNotes()[0].solfege.name).toBe("Ti");
+    expect(musicStore.getActiveNotes()[0].mode).toBe("chromatic");
+    expect(musicStore.getActiveNotes()[0].key).toBe("F#");
+    const notePlayedEvent = dispatchEventSpy.mock.calls.find(
+      ([event]) => event.type === "note-played"
+    )?.[0] as CustomEvent;
+    expect(notePlayedEvent.detail.mode).toBe("chromatic");
+    expect(notePlayedEvent.detail.key).toBe("F#");
 
-  describe('Sequence Management', () => {
-    it('should add notes to sequence', () => {
-      musicStore.addToSequence('Do')
-      musicStore.addToSequence('Re')
-      
-      expect(musicStore.sequence).toEqual(['Do', 'Re'])
-    })
+    await musicStore.releaseNote(noteId!);
+    expect(superdoughMocks.releaseNote).toHaveBeenCalledWith("F5_11_4");
+    expect(musicStore.getActiveNotes()).toHaveLength(0);
+    const noteReleasedEvent = dispatchEventSpy.mock.calls.find(
+      ([event]) => event.type === "note-released"
+    )?.[0] as CustomEvent;
+    expect(noteReleasedEvent.detail.mode).toBe("chromatic");
+    expect(noteReleasedEvent.detail.key).toBe("F#");
+    dispatchEventSpy.mockRestore();
+  });
 
-    it('should limit sequence to 16 notes', () => {
-      // Add 17 notes
-      for (let i = 0; i < 17; i++) {
-        musicStore.addToSequence('Do')
-      }
-      
-      expect(musicStore.sequence).toHaveLength(16)
-    })
+  it("dispatches duration playback with the resolved note for the current mode", async () => {
+    const musicStore = useMusicStore();
 
-    it('should clear sequence', () => {
-      musicStore.addToSequence('Do')
-      musicStore.addToSequence('Re')
-      musicStore.clearSequence()
-      
-      expect(musicStore.sequence).toEqual([])
-    })
+    musicStore.setMode("minor blues");
+    const noteId = await musicStore.playNoteWithDuration(3, 4, "8n");
 
-    it('should remove last note from sequence', () => {
-      musicStore.addToSequence('Do')
-      musicStore.addToSequence('Re')
-      musicStore.removeLastFromSequence()
-      
-      expect(musicStore.sequence).toEqual(['Do'])
-    })
-  })
-
-  describe('Helper Functions', () => {
-    it('should get solfege by name', () => {
-      const solfege = musicStore.getSolfegeByName('Do')
-      expect(solfege).toBeDefined()
-      expect(solfege?.name).toBe('Do')
-    })
-
-    it('should get note frequency', () => {
-      const frequency = musicStore.getNoteFrequency(0, 4)
-      expect(frequency).toBeCloseTo(261.63)
-    })
-
-    it('should get note name', () => {
-      const noteName = musicStore.getNoteName(0, 4)
-      expect(noteName).toBe('C4')
-    })
-
-    it('should check if note is active', async () => {
-      const noteId = await musicStore.attackNote(0)
-      expect(musicStore.isNoteActive(noteId!)).toBe(true)
-      expect(musicStore.isNoteActive('invalid-id')).toBe(false)
-    })
-  })
-
-  describe('Note Input Parsing', () => {
-    it('should parse chromatic note with octave', () => {
-      const parsed = musicStore.parseNoteInput('C4')
-      expect(parsed).toEqual({ solfegeIndex: 0, octave: 4 })
-    })
-
-    it('should parse solfege index input', () => {
-      const parsed = musicStore.parseNoteInput({ solfegeIndex: 2, octave: 5 })
-      expect(parsed).toEqual({ solfegeIndex: 2, octave: 5 })
-    })
-
-    it('should handle invalid note input', () => {
-      const parsed = musicStore.parseNoteInput('X9')
-      expect(parsed).toBeNull()
-    })
-  })
-
-  describe('Melody Management', () => {
-    it('should search melodies', () => {
-      const results = musicStore.searchMelodies('test')
-      expect(results).toEqual([])
-    })
-
-    it('should get melodies by emotion', () => {
-      const results = musicStore.getMelodiesByEmotion('happy')
-      expect(results).toEqual([])
-    })
-
-    it('should get melodies by category', () => {
-      const results = musicStore.melodiesByCategory('intervals')
-      expect(results).toEqual([])
-    })
-
-    it('should get all melodies', () => {
-      const melodies = musicStore.allMelodies
-      expect(melodies).toEqual([])
-    })
-  })
-
-  describe('Legacy Support', () => {
-    it('should maintain backward compatibility with currentNote', async () => {
-      await musicStore.playNote(0)
-      expect(musicStore.currentNote).toBe('Do')
-      
-      // Test timeout clearing
-      vi.useFakeTimers()
-      await musicStore.playNote(0)
-      vi.advanceTimersByTime(2000)
-      expect(musicStore.currentNote).toBe(null)
-      expect(musicStore.isPlaying).toBe(false)
-      vi.useRealTimers()
-    })
-
-    it('should update currentNote when releasing specific note', async () => {
-      const noteId1 = await musicStore.attackNote(0) // Do
-      const noteId2 = await musicStore.attackNote(2) // Mi
-      
-      // Release first note
-      musicStore.releaseNote(noteId1!)
-      
-      // Should still have one active note
-      expect(musicStore.activeNotes.size).toBe(1)
-      expect(musicStore.currentNote).toBe('Mi')
-    })
-  })
-
-  describe('Error Handling', () => {
-    it('should handle invalid solfege index in playNote', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      
-      await musicStore.playNote(10) // Invalid index
-      
-      expect(consoleSpy).not.toHaveBeenCalled() // Should not warn for solfege index
-      consoleSpy.mockRestore()
-    })
-
-    it('should handle invalid chromatic note in playNote', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      
-      await musicStore.playNote('X9' as any)
-      
-      expect(consoleSpy).toHaveBeenCalledWith('Invalid note: X9')
-      consoleSpy.mockRestore()
-    })
-  })
-
-  describe('Event Dispatching', () => {
-    it('should dispatch note-played event with correct details', async () => {
-      await musicStore.playNote(0)
-      
-      expect(window.dispatchEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'note-played',
-          detail: expect.objectContaining({
-            note: expect.objectContaining({ name: 'Do' }),
-            frequency: expect.any(Number),
-            noteName: 'C4',
-            solfegeIndex: 0,
-            octave: 4,
-            instrument: expect.any(String),
-            instrumentConfig: expect.any(Object)
-          })
-        })
-      )
-    })
-
-    it('should dispatch note-released event when releasing notes', async () => {
-      const noteId = await musicStore.attackNote(0)
-      musicStore.releaseNote(noteId!)
-      
-      expect(window.dispatchEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'note-released',
-          detail: expect.objectContaining({
-            note: 'Do',
-            noteId: noteId,
-            noteName: 'C4',
-            frequency: expect.any(Number),
-            octave: 4
-          })
-        })
-      )
-    })
-  })
-
-  describe('Store Persistence', () => {
-    it('should be configured for persistence', () => {
-      // The store should be configured with persist: true
-      // This is tested by checking the store definition
-      expect(musicStore.$id).toBe('music')
-    })
-  })
-})
+    expect(noteId).toContain("sdplay_");
+    expect(superdoughMocks.playNoteWithDuration).toHaveBeenCalledWith(
+      "F#4",
+      250,
+      "piano"
+    );
+  });
+});

--- a/src/components/DrawerKeyboard.vue
+++ b/src/components/DrawerKeyboard.vue
@@ -19,11 +19,9 @@
         >
           <template
             v-for="(solfege, index) in store.solfegeData"
-            :key="`${solfege.name}-${octave}`"
+            :key="`${solfege.intervalName ?? solfege.name}-${index}-${octave}`"
           >
             <KeyboardKey
-              v-if="index < 7"
-              :key="`${solfege.name}-${octave}`"
               :solfege="solfege"
               :octave="octave"
               :solfege-index="index"
@@ -57,9 +55,7 @@ const store = useKeyboardDrawerStore();
 const { animateDrawer } = useKeyboardDrawer(drawerRef) as any;
 
 // Physical keyboard controls integration
-const keyboardControls = useKeyboardControls(
-  computed(() => store.keyboardConfig.mainOctave)
-);
+useKeyboardControls(computed(() => store.keyboardConfig.mainOctave));
 
 // Styling computations
 const drawerClasses = computed(() => {

--- a/src/components/DynamicColorPreview.vue
+++ b/src/components/DynamicColorPreview.vue
@@ -37,14 +37,15 @@
     </div>
     <div class="mapping-info">
       <p>
-        <strong>Mapping:</strong>
-        {{
-          isChromaticMappingEnabled ? "12 Chromatic Notes" : "7 Solfege Notes"
-        }}
+        <strong>Mode:</strong> {{ musicStore.currentKeyDisplay }}
       </p>
       <p>
-        <strong>Hue Distribution:</strong>
-        {{ Math.round(360 / (isChromaticMappingEnabled ? 12 : 7)) }}° per note
+        <strong>Mapping:</strong>
+        {{
+          isChromaticMappingEnabled
+            ? "Static 12-pitch colors"
+            : "Dynamic scale-relative colors"
+        }}
       </p>
     </div>
   </div>
@@ -54,14 +55,20 @@
 import { computed } from "vue";
 import { useColorSystem } from "@/composables/useColorSystem";
 import { useVisualConfig } from "@/composables/useVisualConfig";
+import { useMusicStore } from "@/stores/music";
 
 const { getColorPreview, isDynamicColorsEnabled } = useColorSystem();
 const { dynamicColorConfig } = useVisualConfig();
+const musicStore = useMusicStore();
 
-// Get color preview for middle octave
-const colorPreview = computed(() => getColorPreview("major", 3));
+const colorPreview = computed(() =>
+  getColorPreview(
+    musicStore.currentMode,
+    3,
+    musicStore.currentKey as any
+  )
+);
 
-// Check if chromatic mapping is enabled
 const isChromaticMappingEnabled = computed(
   () => dynamicColorConfig.value.chromaticMapping
 );

--- a/src/components/FloatingPopup.vue
+++ b/src/components/FloatingPopup.vue
@@ -119,12 +119,11 @@ import { useMusicStore } from "@/stores/music";
 import { useColorSystem } from "@/composables/useColorSystem";
 import { useVisualConfig } from "@/composables/useVisualConfig";
 import { Chord, Interval } from "@tonaljs/tonal";
+import type { ChromaticNote } from "@/types/music";
 
 const musicStore = useMusicStore();
 const {
-  getGradient,
-  getPrimaryColor,
-  withAlpha,
+  getPrimaryColorByScaleIndex,
   createGlassmorphBackground,
   createGlassmorphShadow,
   createChordGlassmorphBackground,
@@ -227,9 +226,10 @@ const displayedChord = computed(() => {
 
 // Note colors and gradients
 const getNoteColor = (note: any): string => {
-  return getPrimaryColor(
-    note.solfege.name,
-    musicStore.currentMode,
+  return getPrimaryColorByScaleIndex(
+    note.solfegeIndex,
+    note.mode ?? musicStore.currentMode,
+    (note.key ?? musicStore.currentKey) as ChromaticNote,
     note.octave || 3
   );
 };

--- a/src/components/UnifiedVisualEffects.vue
+++ b/src/components/UnifiedVisualEffects.vue
@@ -20,7 +20,7 @@ import { useMusicStore } from "@/stores/music";
 import { useVisualConfigStore } from "@/stores/visualConfig";
 import { useUnifiedCanvas } from "@/composables/canvas/useUnifiedCanvas";
 import BeatingShapes from "./BeatingShapes.vue";
-import type { SolfegeData } from "@/types/music";
+import type { ChromaticNote, MusicalMode, SolfegeData } from "@/types/music";
 
 const musicStore = useMusicStore();
 const visualConfigStore = useVisualConfigStore();
@@ -50,8 +50,10 @@ function onNotePlayed(event: CustomEvent) {
   const noteId: string | undefined = event.detail.noteId;
   const octave: number | undefined = event.detail.octave;
   const noteName: string | undefined = event.detail.noteName;
+  const mode: MusicalMode | undefined = event.detail.mode;
+  const key: ChromaticNote | undefined = event.detail.key;
 
-  handleNotePlayed(note, frequency, noteId, octave, noteName);
+  handleNotePlayed(note, frequency, noteId, octave, noteName, mode, key);
 }
 
 // Handle note released event - enhanced for polyphonic support

--- a/src/components/keyboard/KeyboardKey.vue
+++ b/src/components/keyboard/KeyboardKey.vue
@@ -49,7 +49,7 @@ import { useSolfegeInteraction } from "@/composables/useSolfegeInteraction";
 import { useColorSystem } from "@/composables/useColorSystem";
 import { useMusicStore } from "@/stores/music";
 import { triggerNoteHaptic } from "@/utils/hapticFeedback";
-import type { SolfegeData } from "@/types/music";
+import type { ChromaticNote, SolfegeData } from "@/types/music";
 
 interface Props {
   solfege: SolfegeData;
@@ -87,23 +87,21 @@ const config = computed(() => store.keyboardConfig);
 // Note tracking
 const noteKey = computed(() => `${props.solfegeIndex}_${props.octave}`);
 const noteName = computed(() => {
-  // Make sure we're reactive to key and mode changes
-  const key = musicStore.currentKey;
-  const mode = musicStore.currentMode;
-  // Force re-evaluation when key or mode changes
+  musicStore.currentKey;
+  musicStore.currentMode;
   return musicStore.getNoteName(props.solfegeIndex, props.octave);
 });
 const isAccidental = computed(() => noteName.value.includes("#"));
 const isPressed = computed(() => store.isKeyPressed(noteKey.value));
 const currentMode = computed(() => musicStore.currentMode);
+const currentKey = computed(() => musicStore.currentKey as ChromaticNote);
 
 // Get background and colors from color system
 const keyColors = computed(() => {
-  // Make sure we're reactive to key changes (affects color system)
-  const key = musicStore.currentKey;
   return getKeyBackground(
-    props.solfege.name,
+    props.solfegeIndex,
     currentMode.value,
+    currentKey.value,
     props.octave,
     config.value.colorMode,
     isAccidental.value,

--- a/src/components/patterns/LiveCard.vue
+++ b/src/components/patterns/LiveCard.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 import { useMusicStore } from "@/stores/music";
 import { usePatternsStore } from "@/stores/patterns";
-import { CHROMATIC_NOTES } from "@/data/musicData";
+import { CHROMATIC_NOTES, MODE_OPTIONS, getModeDefinition } from "@/data/musicData";
 import { Knob } from "@/components/knobs";
 import LiveStrip from "@/components/patterns/LiveStrip.vue";
 import { useLiveStrudelMirror } from "@/composables/useLiveStrudelMirror";
@@ -17,7 +17,9 @@ const bodyOpen = ref(true);
 const sketchSummary = computed(() => {
   const noteCount = patternsStore.currentSketchNotes.length;
   const meta = patternsStore.currentSketchMeta;
-  return `${noteCount} note${noteCount === 1 ? "" : "s"} · ${meta.key} ${meta.mode}`;
+  return `${noteCount} note${noteCount === 1 ? "" : "s"} · ${meta.key} ${
+    getModeDefinition(meta.mode).label
+  }`;
 });
 
 async function toggleSketchPlayback() {
@@ -51,10 +53,7 @@ async function toggleSketchPlayback() {
           <Knob
             :model-value="musicStore.currentMode"
             type="options"
-            :options="[
-              { label: 'Major', value: 'major', color: 'hsl(0, 40%, 75%)' },
-              { label: 'Minor', value: 'minor', color: 'hsl(240, 40%, 75%)' },
-            ]"
+            :options="MODE_OPTIONS"
             label="Mode"
             @update:modelValue="(value) => musicStore.setMode(value as any)"
           />

--- a/src/components/patterns/LiveStrip.vue
+++ b/src/components/patterns/LiveStrip.vue
@@ -13,7 +13,7 @@ import { useLiveStrudelMirror } from "@/composables/useLiveStrudelMirror";
 import { usePatternsStore } from "@/stores/patterns";
 import { useVisualConfigStore } from "@/stores/visualConfig";
 import { useColorSystem } from "@/composables/useColorSystem";
-import { MAJOR_SOLFEGE, MINOR_SOLFEGE } from "@/data";
+import { getSolfegeNameForMode } from "@/data";
 import {
   initSuperdoughAudio,
   getAudioContext,
@@ -28,6 +28,7 @@ import {
 } from "./strudelPlaybackHighlight";
 import type { KeyboardConfig } from "@/types/visual";
 import type { LogNote, PatternNote } from "@/types/patterns";
+import type { MusicalMode } from "@/types/music";
 
 interface StrudelMirrorInstance {
   setCode: (code: string) => void;
@@ -53,7 +54,7 @@ const patternsStore = usePatternsStore();
 const visualConfigStore = useVisualConfigStore();
 const {
   getKeyBackground,
-  getStaticPrimaryColor,
+  getStaticPrimaryColorByScaleIndex,
 } = useColorSystem();
 const { attachEditor, detachEditor, syncCode, setPlaying, setError } =
   useLiveStrudelMirror();
@@ -108,8 +109,7 @@ const generatedCode = computed(() => {
 });
 
 function solfegeName(scaleIndex: number, mode: string): string {
-  const list = mode === "minor" ? MINOR_SOLFEGE : MAJOR_SOLFEGE;
-  return list[scaleIndex]?.name ?? "Do";
+  return getSolfegeNameForMode(mode as MusicalMode, scaleIndex);
 }
 
 function tokenText(note: PatternNote): string {
@@ -163,10 +163,10 @@ function buildNoteSkin(
         ? String(note.scaleIndex + 1)
         : solfegeName(note.scaleIndex, mode);
   const isAccidental = note.note.includes("#");
-  const solfege = solfegeName(note.scaleIndex, mode);
   const { background, primaryColor } = getKeyBackground(
-    solfege,
-    mode as "major" | "minor",
+    note.scaleIndex,
+    mode as MusicalMode,
+    patternsStore.currentSketchMeta.key,
     note.octave,
     config.colorMode,
     isAccidental,
@@ -177,7 +177,12 @@ function buildNoteSkin(
     }
   );
   const passiveColor =
-    getStaticPrimaryColor(solfege, mode as "major" | "minor", note.octave) || primaryColor;
+    getStaticPrimaryColorByScaleIndex(
+      note.scaleIndex,
+      mode as MusicalMode,
+      patternsStore.currentSketchMeta.key,
+      note.octave
+    ) || primaryColor;
   const activeTextColor = keyTextColorValue(config.colorMode, isAccidental);
 
   return {
@@ -222,9 +227,10 @@ const displayTokens = computed((): Token[] => {
     const durationRatio = parseFloat((duration / BAR_MS).toFixed(4));
     const durationSuffix = durationRatio === 1 ? "" : `@${durationRatio}`;
     const tokenLabel = tokenText(note);
-    const color = getStaticPrimaryColor(
-      solfegeName(note.scaleIndex, patternsStore.currentSketchMeta.mode),
+    const color = getStaticPrimaryColorByScaleIndex(
+      note.scaleIndex,
       patternsStore.currentSketchMeta.mode,
+      patternsStore.currentSketchMeta.key,
       note.octave
     );
 

--- a/src/components/patterns/PatternCard.vue
+++ b/src/components/patterns/PatternCard.vue
@@ -4,13 +4,12 @@ import { logNotesToStrudel } from "@/services/StrudelNotation";
 import { toStrudelSound } from "@/composables/useStrudel";
 import { usePatternsStore } from "@/stores/patterns";
 import { useColorSystem } from "@/composables/useColorSystem";
-import { MAJOR_SOLFEGE, MINOR_SOLFEGE } from "@/data";
+import { getModeDefinition, getSolfegeNameForMode } from "@/data";
 import { Knob } from "@/components/knobs";
 import type { Pattern, PatternNote, LogNote } from "@/types/patterns";
-import type { MusicalMode } from "@/types/music";
 
 const patternsStore = usePatternsStore();
-const { getStaticPrimaryColor } = useColorSystem();
+const { getStaticPrimaryColorByScaleIndex } = useColorSystem();
 
 const props = defineProps<{
   pattern: Pattern;
@@ -21,7 +20,7 @@ const copied = ref(false);
 const keyModeLabel = computed(() => {
   const key = props.pattern.key ?? "C";
   const mode = props.pattern.mode ?? "major";
-  return `${key} ${mode}`;
+  return `${key} ${getModeDefinition(mode).label}`;
 });
 
 const noteCount = computed(
@@ -80,13 +79,16 @@ async function copyNotation() {
 
 // ── color strip helpers ───────────────────────────────────────────────────
 function solfegeName(scaleIndex: number, mode: string): string {
-  const list = mode === "minor" ? MINOR_SOLFEGE : MAJOR_SOLFEGE;
-  return list[scaleIndex]?.name ?? "Do";
+  return getSolfegeNameForMode(mode as Pattern["mode"], scaleIndex);
 }
 
 function colorFor(note: PatternNote, pattern: Pattern): string {
-  const name = solfegeName(note.scaleIndex, pattern.mode);
-  return getStaticPrimaryColor(name, pattern.mode as MusicalMode, note.octave);
+  return getStaticPrimaryColorByScaleIndex(
+    note.scaleIndex,
+    pattern.mode,
+    pattern.key,
+    note.octave
+  );
 }
 
 function displayInstrumentName(instrument: string): string {

--- a/src/components/patterns/strudelPlaybackHighlight.ts
+++ b/src/components/patterns/strudelPlaybackHighlight.ts
@@ -14,6 +14,8 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import { isNote } from "@strudel/core";
+import { getSolfegeNameForMode } from "@/data";
+import type { MusicalMode } from "@/types/music";
 
 type NumericLike = number | { valueOf(): number };
 type NotationMode = "solfege" | "note" | "degree";
@@ -32,7 +34,7 @@ type PlaybackHighlightOptions = {
   isProgressiveFillEnabled: boolean;
   isPatternTextColoringEnabled: boolean;
   notationMode: NotationMode;
-  scaleMode: string;
+  scaleMode: MusicalMode;
   noteSkins: NoteSkin[];
 };
 
@@ -72,13 +74,9 @@ type InlineMetaToken = {
 };
 
 const INLINE_META_REGEX = /(?:@(?:\d+(?:\.\d+)?)|:(?:\d+(?:\.\d+)?))/g;
-const RELATIVE_NOTE_REGEX = /(?<![@.\w])[0-6](?=@|\b)/g;
+const RELATIVE_NOTE_REGEX = /(?<![@.\w])\d{1,2}(?=@|\b)/g;
 const ABSOLUTE_NOTE_REGEX = /\b[a-gA-G](?:[#bsf]+)?\d\b/g;
 const REST_TOKEN_REGEX = /~(?=@|\b)/g;
-const SOLFEGE_LABELS = {
-  major: ["Do", "Re", "Mi", "Fa", "Sol", "La", "Ti"],
-  minor: ["Do", "Re", "Me", "Fa", "Sol", "Le", "Te"],
-} as const;
 
 const defaultOptions: PlaybackHighlightOptions = {
   isNoteColoringEnabled: true,
@@ -493,9 +491,10 @@ function resolveDisplayLabel(note: NoteToken, options: PlaybackHighlightOptions)
   }
 
   if (options.notationMode === "solfege") {
-    const labels =
-      options.scaleMode === "minor" ? SOLFEGE_LABELS.minor : SOLFEGE_LABELS.major;
-    return labels[Number(note.text)] ?? note.text;
+    return getSolfegeNameForMode(
+      options.scaleMode as MusicalMode,
+      Number(note.text)
+    );
   }
 
   return undefined;
@@ -697,7 +696,7 @@ function noteToHslColor(note: string) {
 }
 
 function degreeToHslColor(degree: number) {
-  const hueInterval = 360 / 7;
+  const hueInterval = 360 / 12;
   const hue = (degree * hueInterval + hueInterval / 2) % 360;
 
   return `hsl(${hue} 88% 72%)`;

--- a/src/composables/canvas/useAmbientRenderer.ts
+++ b/src/composables/canvas/useAmbientRenderer.ts
@@ -4,8 +4,58 @@
  */
 
 import type { AmbientConfig } from "@/types/visual";
+import type { ChromaticNote, MusicalMode } from "@/types/music";
+import { getScaleForMode } from "@/data";
+import { useColorSystem } from "../useColorSystem";
+
+const HSLA_PATTERN =
+  /hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%(?:\s*,\s*([\d.]+))?\s*\)/i;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function tuneAmbientColor(
+  color: string,
+  saturationMultiplier: number,
+  brightnessMultiplier: number,
+  alpha: number
+): string {
+  const match = color.match(HSLA_PATTERN);
+  if (!match) {
+    return color;
+  }
+
+  const hue = Number(match[1]);
+  const saturation = clamp(Number(match[2]) * saturationMultiplier, 0, 100);
+  const lightness = clamp(Number(match[3]) * brightnessMultiplier, 0, 100);
+
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, ${clamp(alpha, 0, 1)})`;
+}
+
+function resolveAmbientContext(musicStore: any) {
+  const activeNotes =
+    typeof musicStore?.getActiveNotes === "function"
+      ? musicStore.getActiveNotes()
+      : [];
+  const firstActiveNote = activeNotes[0];
+  const mode = (firstActiveNote?.mode ?? musicStore?.currentMode ?? "major") as MusicalMode;
+  const key = (firstActiveNote?.key ?? musicStore?.currentKey ?? "C") as ChromaticNote;
+  const scale = getScaleForMode(mode);
+  const accentIndex = scale.degreeCount > 1 ? Math.floor(scale.degreeCount / 2) : 0;
+  const highlightIndex = firstActiveNote?.solfegeIndex ?? accentIndex;
+
+  return {
+    mode,
+    key,
+    accentIndex,
+    highlightIndex,
+  };
+}
 
 export function useAmbientRenderer() {
+  const { getStaticPrimaryColorByScaleIndex } = useColorSystem();
+
   /**
    * Render subtle texture overlay
    */
@@ -41,6 +91,10 @@ export function useAmbientRenderer() {
 
   /**
    * Render ambient background
+   *
+   * Note: the config field names retain their legacy "major/minor" keys so
+   * persisted configs remain compatible, but they now control a tonic/accent
+   * ambient wash rather than a binary major/minor split.
    */
   const renderAmbientBackground = (
     ctx: CanvasRenderingContext2D,
@@ -48,7 +102,7 @@ export function useAmbientRenderer() {
     ambientConfig: AmbientConfig,
     canvasWidth: number,
     canvasHeight: number,
-    _musicStore: any,
+    musicStore: any,
     getCachedGradient: (
       key: string,
       createFn: () => CanvasGradient
@@ -56,8 +110,41 @@ export function useAmbientRenderer() {
   ) => {
     if (!ctx) return;
 
-    // Simple black background with subtle warm lighting
-    const gradientKey = `ambient-warm`;
+    const context = resolveAmbientContext(musicStore);
+    const tonicColor = getStaticPrimaryColorByScaleIndex(
+      0,
+      context.mode,
+      context.key,
+      4
+    );
+    const accentColor = getStaticPrimaryColorByScaleIndex(
+      context.highlightIndex,
+      context.mode,
+      context.key,
+      4
+    );
+    const supportColor = getStaticPrimaryColorByScaleIndex(
+      context.accentIndex,
+      context.mode,
+      context.key,
+      3
+    );
+
+    const gradientKey = [
+      "ambient",
+      context.key,
+      context.mode,
+      context.highlightIndex,
+      canvasWidth,
+      canvasHeight,
+      ambientConfig.opacityMajor,
+      ambientConfig.opacityMinor,
+      ambientConfig.brightnessMajor,
+      ambientConfig.brightnessMinor,
+      ambientConfig.saturationMajor,
+      ambientConfig.saturationMinor,
+    ].join("-");
+
     const gradient = getCachedGradient(gradientKey, () => {
       const grad = ctx.createRadialGradient(
         canvasWidth * 0.5,
@@ -68,10 +155,34 @@ export function useAmbientRenderer() {
         Math.max(canvasWidth, canvasHeight) * 0.8
       );
 
-      // Warm subtle lighting on black
-      grad.addColorStop(0, "rgba(40, 30, 20, 0.3)"); // Warm center
-      grad.addColorStop(0.6, "rgba(20, 15, 10, 0.6)"); // Darker warm
-      grad.addColorStop(1, "rgba(0, 0, 0, 0.9)"); // Black edges
+      grad.addColorStop(
+        0,
+        tuneAmbientColor(
+          tonicColor,
+          ambientConfig.saturationMajor,
+          ambientConfig.brightnessMajor,
+          ambientConfig.opacityMajor * 0.55
+        )
+      );
+      grad.addColorStop(
+        0.45,
+        tuneAmbientColor(
+          accentColor,
+          ambientConfig.saturationMinor,
+          ambientConfig.brightnessMinor,
+          ambientConfig.opacityMinor * 0.45
+        )
+      );
+      grad.addColorStop(
+        0.72,
+        tuneAmbientColor(
+          supportColor,
+          ambientConfig.saturationMinor,
+          ambientConfig.brightnessMinor,
+          ambientConfig.opacityMinor * 0.2
+        )
+      );
+      grad.addColorStop(1, "rgba(0, 0, 0, 0.94)");
 
       return grad;
     });
@@ -80,7 +191,7 @@ export function useAmbientRenderer() {
     ctx.fillStyle = "black";
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
 
-    // Apply warm lighting gradient
+    // Apply mode-aware ambient lighting gradient
     ctx.fillStyle = gradient;
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
 

--- a/src/composables/canvas/useBlobRenderer.ts
+++ b/src/composables/canvas/useBlobRenderer.ts
@@ -5,11 +5,11 @@
  */
 
 import type { ActiveBlob } from "@/types/canvas";
-import type { SolfegeData } from "@/types/music";
+import type { ChromaticNote, MusicalMode, SolfegeData } from "@/types/music";
 import type { BlobConfig } from "@/types/visual";
 import { useColorSystem } from "../useColorSystem";
 import { createVisualFrequency } from "@/utils/visualEffects";
-import { CHROMATIC_NOTES } from "@/data/notes";
+import { CHROMATIC_NOTES, getScaleForMode } from "@/data";
 import { useKeyboardDrawerStore } from "@/stores/keyboardDrawer";
 
 export function useBlobRenderer() {
@@ -124,21 +124,11 @@ export function useBlobRenderer() {
     currentKey: string,
     currentMode: string
   ): string => {
-    // Map solfege numbers to scale intervals
-    const majorIntervals = [0, 2, 4, 5, 7, 9, 11]; // Do, Re, Mi, Fa, Sol, La, Ti
-    const minorIntervals = [0, 2, 3, 5, 7, 8, 10]; // Do, Re, Me, Fa, Sol, Le, Te
-
-    const intervals = currentMode === "major" ? majorIntervals : minorIntervals;
-    const solfegeIndex = (solfegeData.number - 1) % 7; // Convert 1-8 to 0-6
-    const interval = intervals[solfegeIndex];
-
-    // Get the key's chromatic position
-    const keyIndex = CHROMATIC_NOTES.indexOf(currentKey as any);
-
-    // Calculate the note's chromatic position
-    const noteIndex = (keyIndex + interval) % 12;
-
-    return CHROMATIC_NOTES[noteIndex];
+    const scale = getScaleForMode(currentMode as MusicalMode);
+    const solfegeIndex = ((solfegeData.number - 1) % scale.degreeCount + scale.degreeCount) % scale.degreeCount;
+    const interval = scale.intervals[solfegeIndex] ?? 0;
+    const keyIndex = CHROMATIC_NOTES.indexOf(currentKey as ChromaticNote);
+    return CHROMATIC_NOTES[(keyIndex + interval + 12) % 12];
   };
 
   // Blob state - now supports both note names and noteIds for polyphonic tracking
@@ -216,7 +206,10 @@ export function useBlobRenderer() {
 
     // Calculate position using Circle of Fifths with blob size consideration
     // Use solfege index directly for more accurate positioning
-    const solfegeIndex = (note.number - 1) % 7; // Convert 1-8 to 0-6
+    const scale = getScaleForMode((currentMode || "major") as MusicalMode);
+    const solfegeIndex =
+      ((note.number - 1) % scale.degreeCount + scale.degreeCount) %
+      scale.degreeCount;
 
     // Get the highest visible octave for octave offset calculation
     const visibleOctaves = keyboardDrawerStore.visibleOctaves;
@@ -257,6 +250,9 @@ export function useBlobRenderer() {
       driftVy: (Math.random() - 0.5) * blobConfig.driftSpeed * 0.3, // 30% of normal drift
       vibrationPhase: Math.random() * Math.PI * 2,
       scale: 0, // Start at zero scale for grow-in animation
+      mode: (currentMode || "major") as MusicalMode,
+      key: (currentKey || "C") as ChromaticNote,
+      octave: currentOctave,
     };
 
     // Store the active blob using the appropriate key
@@ -434,11 +430,15 @@ export function useBlobRenderer() {
       // Use current opacity for colors
       const primaryColor = getPrimaryColor(
         blob.note.name,
-        musicStore.currentMode
+        blob.mode,
+        blob.octave,
+        blob.key
       );
       const accentColor = getAccentColor(
         blob.note.name,
-        musicStore.currentMode
+        blob.mode,
+        blob.octave,
+        blob.key
       );
 
       // Apply opacity to colors using withAlpha from color system

--- a/src/composables/canvas/useHilbertScopeRenderer.ts
+++ b/src/composables/canvas/useHilbertScopeRenderer.ts
@@ -328,7 +328,14 @@ export function useHilbertScopeRenderer() {
       // Use the first active note's color, or blend multiple
       const firstNote = activeNotes[0];
       const noteName = firstNote.solfege.name;
-      const noteColor = colorSystem.getPrimaryColor(noteName, musicStore.currentMode);
+      const noteMode = firstNote.mode ?? musicStore.currentMode;
+      const noteKey = firstNote.key ?? musicStore.currentKey;
+      const noteColor = colorSystem.getPrimaryColor(
+        noteName,
+        noteMode,
+        firstNote.octave,
+        noteKey as any
+      );
       
       // Modulate opacity based on amplitude
       const alphaValue = 0.5 + amplitude * 0.5; // Range from 0.5 to 1.0
@@ -342,14 +349,24 @@ export function useHilbertScopeRenderer() {
         // Pick a note from the scale based on amplitude
         const noteIndex = Math.floor(amplitude * (scaleNotes.length - 1));
         const scaleNote = scaleNotes[noteIndex];
-        const noteColor = colorSystem.getPrimaryColor(scaleNote.name, musicStore.currentMode);
+        const noteColor = colorSystem.getPrimaryColor(
+          scaleNote.name,
+          musicStore.currentMode,
+          3,
+          musicStore.currentKey as any
+        );
         
         const alphaValue = 0.3 + amplitude * 0.7;
         strokeColor = colorSystem.withAlpha(noteColor, alphaValue);
         glowColor = noteColor;
       } else {
         // Ultimate fallback
-        const defaultColor = colorSystem.getPrimaryColor('C', 'major');
+        const defaultColor = colorSystem.getPrimaryColorByScaleIndex(
+          0,
+          musicStore.currentMode,
+          musicStore.currentKey as any,
+          3
+        );
         const alphaValue = 0.3 + amplitude * 0.7;
         strokeColor = colorSystem.withAlpha(defaultColor, alphaValue);
         glowColor = defaultColor;

--- a/src/composables/canvas/useParticleSystem.ts
+++ b/src/composables/canvas/useParticleSystem.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Particle } from "@/types/canvas";
-import type { SolfegeData } from "@/types/music";
+import type { ChromaticNote, MusicalMode, SolfegeData } from "@/types/music";
 import type { ParticleConfig } from "@/types/visual";
 import { useColorSystem } from "../useColorSystem";
 
@@ -57,7 +57,8 @@ export function useParticleSystem() {
     particleConfig: ParticleConfig,
     canvasWidth: number,
     canvasHeight: number,
-    musicStore: any,
+    mode: MusicalMode,
+    key: ChromaticNote,
     count?: number
   ) => {
     if (!particleConfig.isEnabled) return;
@@ -72,7 +73,12 @@ export function useParticleSystem() {
       particle.y = Math.random() * canvasHeight;
       particle.vx = (Math.random() - 0.5) * particleConfig.speed;
       particle.vy = (Math.random() - 0.5) * particleConfig.speed;
-      particle.color = getFleckColor(note.name, musicStore.currentMode);
+      particle.color = getFleckColor(
+        note.name,
+        mode,
+        3,
+        key
+      );
       particle.shape = note.fleckShape || "circle";
       particle.size =
         particleConfig.sizeMin +

--- a/src/composables/canvas/useStringRenderer.ts
+++ b/src/composables/canvas/useStringRenderer.ts
@@ -19,9 +19,10 @@ import { useMusicStore } from "@/stores/music";
 import { useKeyboardDrawerStore } from "@/stores/keyboardDrawer";
 import { useVisualConfigStore } from "@/stores/visualConfig";
 import useGSAP from "../useGSAP";
+import type { ChromaticNote, MusicalMode } from "@/types/music";
 
 export function useStringRenderer() {
-  const { getPrimaryColor } = useColorSystem();
+  const { getPrimaryColor, getPrimaryColorByScaleIndex } = useColorSystem();
   const { gsap } = useGSAP();
   const musicStore = useMusicStore();
   const keyboardDrawerStore = useKeyboardDrawerStore();
@@ -37,14 +38,19 @@ export function useStringRenderer() {
   // Event-based activation for sequencer notes
   const eventActivatedStrings = ref(
     new Map<
-      number,
+      string,
       {
         frequency: number;
         octave: number;
+        mode: MusicalMode;
+        key: ChromaticNote;
         endTime: number;
       }
     >()
   );
+
+  const getStringActivationKey = (solfegeIndex: number, octave: number) =>
+    `${solfegeIndex}_${octave}`;
 
   /**
    * Initialize string configurations
@@ -94,7 +100,12 @@ export function useStringRenderer() {
           amplitude: 0,
           frequency: 1,
           phase: Math.random() * Math.PI * 2,
-          color: getPrimaryColor(solfege.name, "major", octave),
+          color: getPrimaryColorByScaleIndex(
+            degreeIndex,
+            musicStore.currentMode,
+            musicStore.currentKey as any,
+            octave
+          ),
           opacity: stringConfig.baseOpacity,
           isActive: false,
           noteIndex: degreeIndex,
@@ -139,7 +150,15 @@ export function useStringRenderer() {
    * Handle note played events (for sequencer integration)
    */
   const handleNotePlayed = (event: CustomEvent) => {
-    const { solfegeIndex, frequency, octave, duration, durationMs: eventDurationMs } = event.detail;
+    const {
+      solfegeIndex,
+      frequency,
+      octave,
+      duration,
+      durationMs: eventDurationMs,
+      mode,
+      key,
+    } = event.detail;
 
     if (solfegeIndex !== undefined && frequency && octave) {
       // Calculate end time based on duration or default to 500ms
@@ -163,9 +182,11 @@ export function useStringRenderer() {
       const endTime = Date.now() + durationMs;
 
       // Add to event-activated strings
-      eventActivatedStrings.value.set(solfegeIndex, {
+      eventActivatedStrings.value.set(getStringActivationKey(solfegeIndex, octave), {
         frequency,
         octave,
+        mode: (mode ?? musicStore.currentMode) as MusicalMode,
+        key: (key ?? musicStore.currentKey) as ChromaticNote,
         endTime,
       });
     }
@@ -177,11 +198,11 @@ export function useStringRenderer() {
   const cleanupExpiredActivations = () => {
     const now = Date.now();
     for (const [
-      solfegeIndex,
+      activationKey,
       activation,
     ] of eventActivatedStrings.value.entries()) {
       if (now > activation.endTime) {
-        eventActivatedStrings.value.delete(solfegeIndex);
+        eventActivatedStrings.value.delete(activationKey);
       }
     }
   };
@@ -203,14 +224,17 @@ export function useStringRenderer() {
 
       // Check if this string's note is currently active for its specific octave (from direct input)
       const activeNotes = musicStore.getActiveNotes();
-      const isStringActiveFromInput = activeNotes.some(
+      const matchingActiveNote = activeNotes.find(
         (activeNote: any) =>
           activeNote.solfegeIndex === string.noteIndex &&
           activeNote.octave === string.octave
       );
+      const isStringActiveFromInput = Boolean(matchingActiveNote);
 
       // Check if this string is activated by sequencer events (for the specific octave)
-      const eventActivation = eventActivatedStrings.value.get(string.noteIndex);
+      const eventActivation = eventActivatedStrings.value.get(
+        getStringActivationKey(string.noteIndex, string.octave)
+      );
       const isStringActiveFromEvent =
         eventActivation &&
         Date.now() <= eventActivation.endTime &&
@@ -231,20 +255,26 @@ export function useStringRenderer() {
           stringConfig.activeOpacity,
           stringConfig.opacityInterpolationSpeed
         );
-        string.color = getPrimaryColor(solfege.name, musicStore.currentMode);
+        const noteMode = (matchingActiveNote?.mode ??
+          eventActivation?.mode ??
+          musicStore.currentMode) as MusicalMode;
+        const noteKey = (matchingActiveNote?.key ??
+          eventActivation?.key ??
+          musicStore.currentKey) as ChromaticNote;
+        string.color = getPrimaryColor(
+          solfege.name,
+          noteMode,
+          string.octave,
+          noteKey
+        );
 
         // Determine frequency for visual vibration
         let visualFrequency;
 
         if (isStringActiveFromInput) {
           // Use the frequency from the matching octave note
-          const matchingNote = activeNotes.find(
-            (activeNote: any) =>
-              activeNote.solfegeIndex === string.noteIndex &&
-              activeNote.octave === string.octave
-          );
           visualFrequency =
-            matchingNote?.frequency ||
+            matchingActiveNote?.frequency ||
             musicStore.getNoteFrequency(string.noteIndex, string.octave);
         } else if (eventActivation) {
           // Use frequency from event activation (sequencer)

--- a/src/composables/canvas/useUnifiedCanvas.ts
+++ b/src/composables/canvas/useUnifiedCanvas.ts
@@ -2,7 +2,7 @@ import { ref, type Ref } from "vue";
 import { useMusicStore } from "@/stores/music";
 import { useVisualConfig } from "@/composables/useVisualConfig";
 import { useAnimationLifecycle } from "@/composables/useAnimationLifecycle";
-import type { SolfegeData } from "@/types/music";
+import type { ChromaticNote, MusicalMode, SolfegeData } from "@/types/music";
 import { useBlobRenderer } from "./useBlobRenderer";
 import { useParticleSystem } from "./useParticleSystem";
 import { useStringRenderer } from "./useStringRenderer";
@@ -239,8 +239,13 @@ export function useUnifiedCanvas(canvasRef: Ref<HTMLCanvasElement | null>) {
     frequency: number,
     noteId?: string,
     octave?: number,
-    _noteName?: string
+    _noteName?: string,
+    mode?: MusicalMode,
+    key?: ChromaticNote
   ) => {
+    const noteMode = mode ?? musicStore.currentMode;
+    const noteKey = key ?? (musicStore.currentKey as ChromaticNote);
+
     // Create blob using Circle of Fifths positioning
     // No longer need to calculate x,y - the blob renderer handles positioning
     blobRenderer.createBlob(
@@ -252,8 +257,8 @@ export function useUnifiedCanvas(canvasRef: Ref<HTMLCanvasElement | null>) {
       canvasHeight.value,
       blobConfig.value,
       noteId, // Pass noteId for tracking
-      musicStore.currentKey, // Pass current key for circle positioning
-      musicStore.currentMode, // Pass current mode for circle direction
+      noteKey, // Pass event key snapshot for circle positioning
+      noteMode, // Pass event mode snapshot for scale positioning
       octave // Pass octave for vertical offset positioning
     );
 
@@ -269,7 +274,8 @@ export function useUnifiedCanvas(canvasRef: Ref<HTMLCanvasElement | null>) {
       particleConfig.value,
       canvasWidth.value,
       canvasHeight.value,
-      musicStore,
+      noteMode,
+      noteKey,
       particleCount
     );
   };

--- a/src/composables/useColorSystem.ts
+++ b/src/composables/useColorSystem.ts
@@ -1,87 +1,86 @@
 /**
  * Unified Color System
- * Single source of truth for all color-related functionality in the application
- * Combines dynamic color generation with reactive Vue composable patterns
+ * Dynamic colors are scale-relative; the persisted chromaticMapping toggle
+ * is reinterpreted as static 12-pitch-class coloring.
  */
 
-import { ref, computed, onUnmounted } from "vue";
+import { computed, onUnmounted, ref } from "vue";
 import { useVisualConfig } from "./useVisualConfig";
 import type {
-  NoteColorRelationships,
+  ChromaticNote,
   DynamicColorConfig,
   MusicalMode,
+  NoteColorRelationships,
 } from "@/types";
-import { CHROMATIC_NOTES, SOLFEGE_NOTES } from "@/data";
+import {
+  ALL_SOLFEGE_NOTES,
+  CHROMATIC_NOTES,
+  getScaleForMode,
+} from "@/data";
 
-/**
- * Solfege note names for mapping
- */
+const FLAT_TO_SHARP_MAP: Record<string, ChromaticNote> = {
+  Db: "C#",
+  Eb: "D#",
+  Gb: "F#",
+  Ab: "G#",
+  Bb: "A#",
+};
 
-/**
- * Calculate base hue for a note index (center of the hue interval)
- */
-function calculateBaseHue(
-  noteIndex: number,
-  chromaticMapping: boolean
-): number {
-  const totalNotes = chromaticMapping ? 12 : 7;
-  const hueInterval = 360 / totalNotes;
-  // Place hue at the center of the interval
+const EDGE_CASE_MAP: Record<string, ChromaticNote> = {
+  "E#": "F",
+  "B#": "C",
+  Fb: "E",
+  Cb: "B",
+};
+
+function normalizeIndex(index: number, base: number): number {
+  return ((index % base) + base) % base;
+}
+
+function calculateChromaticBaseHue(noteIndex: number): number {
+  const hueInterval = 360 / 12;
   return (noteIndex * hueInterval + hueInterval / 2) % 360;
 }
 
-/**
- * Calculate octave-based lightness
- */
+function calculateDegreeBaseHue(
+  scaleIndex: number,
+  degreeCount: number,
+  key: ChromaticNote
+): number {
+  const tonicIndex = CHROMATIC_NOTES.indexOf(key);
+  const tonicHue = calculateChromaticBaseHue(Math.max(0, tonicIndex));
+  const hueInterval = 360 / degreeCount;
+  return (tonicHue + normalizeIndex(scaleIndex, degreeCount) * hueInterval) % 360;
+}
 
 function calculateOctaveLightness(
   octave: number,
   baseLightness: number,
   lightnessRange: number
 ): number {
-  // Map octaves 2-8 to lightness range with more dramatic differences
   const normalizedOctave = Math.max(2, Math.min(8, octave));
-  const octaveRatio = (normalizedOctave - 2) / 6; // 0 to 1 across 6 octaves
-
-  // Use a more dramatic lightness curve for better visual distinction
-  // Lower octaves are much darker, higher octaves are much lighter
-  const minLightness = Math.max(0.15, baseLightness - lightnessRange / 2); // Ensure minimum 15%
-  const maxLightness = Math.min(0.85, baseLightness + lightnessRange / 2); // Ensure maximum 85%
-
-  // Apply a slight curve to make the differences more pronounced
-  // This makes lower octaves darker and higher octaves lighter more dramatically
-  const curvedRatio = Math.pow(octaveRatio, 0.8); // Slight curve for better distribution
-
+  const octaveRatio = (normalizedOctave - 2) / 6;
+  const minLightness = Math.max(0.15, baseLightness - lightnessRange / 2);
+  const maxLightness = Math.min(0.85, baseLightness + lightnessRange / 2);
+  const curvedRatio = Math.pow(octaveRatio, 0.8);
   const lightness = minLightness + curvedRatio * (maxLightness - minLightness);
-
-  // Ensure lightness stays within valid range
   return Math.max(0.1, Math.min(0.9, lightness));
 }
 
-/**
- * Generate color relationships from hue, saturation, and lightness
- */
 function generateColorRelationships(
   hue: number,
   saturation: number,
   lightness: number
 ): NoteColorRelationships {
-  // Primary: base color
   const primary = `hsla(${hue}, ${saturation * 100}%, ${lightness * 100}%, 1)`;
-
-  // Accent: complementary hue (180° opposite)
   const accentHue = (hue + 180) % 360;
   const accent = `hsla(${accentHue}, ${saturation * 100}%, ${
     lightness * 100
   }%, 1)`;
-
-  // Secondary: triadic harmony (+120°)
   const secondaryHue = (hue + 120) % 360;
   const secondary = `hsla(${secondaryHue}, ${saturation * 100}%, ${
     lightness * 100
   }%, 1)`;
-
-  // Tertiary: triadic harmony (-120°)
   const tertiaryHue = (hue + 240) % 360;
   const tertiary = `hsla(${tertiaryHue}, ${saturation * 100}%, ${
     lightness * 100
@@ -90,83 +89,152 @@ function generateColorRelationships(
   return { primary, accent, secondary, tertiary };
 }
 
-/**
- * Generate animated hue within the note's range
- */
 function generateAnimatedHue(
   baseHue: number,
   amplitude: number,
   time: number,
   speed: number,
-  chromaticMapping: boolean
+  intervalCount: number
 ): number {
-  const totalNotes = chromaticMapping ? 12 : 7;
-  const hueInterval = 360 / totalNotes;
-
-  // Ensure amplitude doesn't exceed half the interval to prevent overlap
-  const maxAmplitude = hueInterval / 2;
-  const clampedAmplitude = Math.min(amplitude, maxAmplitude);
-
-  // Use sine wave for smooth animation
+  const hueInterval = 360 / intervalCount;
+  const clampedAmplitude = Math.min(amplitude, hueInterval / 2);
   const animationOffset = Math.sin(time * speed * 0.001) * clampedAmplitude;
-
   return (baseHue + animationOffset + 360) % 360;
 }
 
-/**
- * Get note index from name
- */
-function getNoteIndex(noteName: string, chromaticMapping: boolean): number {
-  const cleanName = noteName.replace("'", "");
+function normalizeChromaticNote(noteName: string): ChromaticNote | null {
+  const cleanName = noteName.replace(/[0-9']/g, "");
 
-  if (chromaticMapping) {
-    return CHROMATIC_NOTES.indexOf(cleanName as any);
-  } else {
-    return SOLFEGE_NOTES.indexOf(cleanName);
+  if (CHROMATIC_NOTES.includes(cleanName as ChromaticNote)) {
+    return cleanName as ChromaticNote;
   }
+
+  if (EDGE_CASE_MAP[cleanName]) {
+    return EDGE_CASE_MAP[cleanName];
+  }
+
+  return FLAT_TO_SHARP_MAP[cleanName] ?? null;
 }
 
-/**
- * Generate dynamic colors for a note
- */
-function generateDynamicNoteColors(
-  noteIndex: number,
+function getChromaticNoteForScaleIndex(
+  scaleIndex: number,
+  mode: MusicalMode,
+  key: ChromaticNote
+): ChromaticNote | null {
+  const scale = getScaleForMode(mode);
+  const normalizedScaleIndex = normalizeIndex(scaleIndex, scale.degreeCount);
+  const semitoneOffset = scale.intervals[normalizedScaleIndex];
+  const tonicIndex = CHROMATIC_NOTES.indexOf(key);
+
+  if (tonicIndex === -1 || semitoneOffset == null) {
+    return null;
+  }
+
+  return CHROMATIC_NOTES[(tonicIndex + semitoneOffset) % 12];
+}
+
+function getScaleIndexForSolfegeName(
+  noteName: string,
+  mode: MusicalMode
+): number | null {
+  const scale = getScaleForMode(mode);
+  const cleanName = noteName.replace("'", "");
+  const matchIndex = scale.solfege.findIndex(
+    (note) => note.name.toLowerCase() === cleanName.toLowerCase()
+  );
+
+  return matchIndex === -1 ? null : matchIndex;
+}
+
+function getFallbackScaleIndexForChromaticNote(
+  noteName: ChromaticNote,
+  mode: MusicalMode,
+  key: ChromaticNote
+): number | null {
+  const scale = getScaleForMode(mode);
+  const chromaticIndex = CHROMATIC_NOTES.indexOf(noteName);
+  const tonicIndex = CHROMATIC_NOTES.indexOf(key);
+
+  if (chromaticIndex === -1 || tonicIndex === -1) {
+    return null;
+  }
+
+  const relativeSemitone = (chromaticIndex - tonicIndex + 12) % 12;
+  let fallbackIndex = 0;
+
+  for (let index = 0; index < scale.intervals.length; index++) {
+    if (scale.intervals[index] <= relativeSemitone) {
+      fallbackIndex = index;
+    } else {
+      break;
+    }
+  }
+
+  return fallbackIndex;
+}
+
+function getDynamicNoteColors(
+  scaleIndex: number,
   octave: number,
+  key: ChromaticNote,
+  degreeCount: number,
   config: DynamicColorConfig,
   time?: number
 ): NoteColorRelationships {
-  const baseHue = calculateBaseHue(noteIndex, config.chromaticMapping);
-
-  // Use animated hue if time is provided, otherwise use base hue
-  const currentHue =
+  const baseHue = calculateDegreeBaseHue(scaleIndex, degreeCount, key);
+  const hue =
     time !== undefined
       ? generateAnimatedHue(
           baseHue,
           config.hueAnimationAmplitude,
           time,
           config.animationSpeed,
-          config.chromaticMapping
+          degreeCount
         )
       : baseHue;
-
   const lightness = calculateOctaveLightness(
     octave,
     config.baseLightness,
     config.lightnessRange
   );
 
-  return generateColorRelationships(currentHue, config.saturation, lightness);
+  return generateColorRelationships(hue, config.saturation, lightness);
 }
 
-// Singleton instance for animation management
+function getStaticChromaticNoteColors(
+  chromaticNote: ChromaticNote,
+  octave: number,
+  config: DynamicColorConfig,
+  time?: number
+): NoteColorRelationships {
+  const noteIndex = CHROMATIC_NOTES.indexOf(chromaticNote);
+  const baseHue = calculateChromaticBaseHue(Math.max(0, noteIndex));
+  const hue =
+    time !== undefined
+      ? generateAnimatedHue(
+          baseHue,
+          config.hueAnimationAmplitude,
+          time,
+          config.animationSpeed,
+          12
+        )
+      : baseHue;
+  const lightness = calculateOctaveLightness(
+    octave,
+    config.baseLightness,
+    config.lightnessRange
+  );
+
+  return generateColorRelationships(hue, config.saturation, lightness);
+}
+
 let animationId: number | null = null;
 const animationTime = ref(0);
 
-/**
- * Start global animation loop
- */
 function startGlobalAnimation() {
-  if (animationId) return;
+  if (animationId) {
+    return;
+  }
 
   const animate = () => {
     animationTime.value = Date.now();
@@ -176,260 +244,261 @@ function startGlobalAnimation() {
   animate();
 }
 
-/**
- * Stop global animation loop
- */
-function stopGlobalAnimation() {
-  if (animationId) {
-    cancelAnimationFrame(animationId);
-    animationId = null;
-  }
-}
-
-/**
- * Unified Color System Composable
- */
 export function useColorSystem() {
   const { dynamicColorConfig } = useVisualConfig();
 
-  // Start animation when composable is used
   startGlobalAnimation();
 
-  // Cleanup on unmount
   onUnmounted(() => {
-    // Note: Don't stop global animation here as other components might be using it
-    // Animation will be cleaned up when the app is destroyed
+    // Intentionally left running while the app is mounted.
   });
 
-  /**
-   * Generate colors for a solfege note
-   */
-  const getNoteColors = (
-    noteName: string,
+  const isStaticChromaticColors = computed(
+    () => dynamicColorConfig.value.chromaticMapping
+  );
+
+  const getNoteColorsByScaleIndex = (
+    scaleIndex: number,
     mode: MusicalMode = "major",
+    key: ChromaticNote = "C",
     octave: number = 3,
     animated: boolean = true
   ): NoteColorRelationships => {
     const config = dynamicColorConfig.value;
-    const cleanNoteName = noteName.replace("'", "");
+    const scale = getScaleForMode(mode);
+    const normalizedScaleIndex = normalizeIndex(scaleIndex, scale.degreeCount);
+    const time = animated ? animationTime.value : undefined;
 
-    const noteIndex = getNoteIndex(cleanNoteName, config.chromaticMapping);
+    if (isStaticChromaticColors.value) {
+      const chromaticNote = getChromaticNoteForScaleIndex(
+        normalizedScaleIndex,
+        mode,
+        key
+      );
 
-    if (noteIndex === -1) {
-      // Invalid note name, return default colors
-      return {
-        primary: "hsla(0, 80%, 50%, 1)",
-        accent: "hsla(180, 80%, 50%, 1)",
-        secondary: "hsla(120, 80%, 50%, 1)",
-        tertiary: "hsla(240, 80%, 50%, 1)",
-      };
+      if (chromaticNote) {
+        return getStaticChromaticNoteColors(chromaticNote, octave, config, time);
+      }
     }
 
-    const time = animated ? animationTime.value : undefined;
-    return generateDynamicNoteColors(noteIndex, octave, config, time);
+    return getDynamicNoteColors(
+      normalizedScaleIndex,
+      octave,
+      key,
+      scale.degreeCount,
+      config,
+      time
+    );
   };
 
-  /**
-   * Get primary color for a note
-   */
+  const getNoteColors = (
+    noteName: string,
+    mode: MusicalMode = "major",
+    octave: number = 3,
+    animated: boolean = true,
+    key: ChromaticNote = "C"
+  ): NoteColorRelationships => {
+    const scaleIndex = getScaleIndexForSolfegeName(noteName, mode);
+    if (scaleIndex !== null) {
+      return getNoteColorsByScaleIndex(scaleIndex, mode, key, octave, animated);
+    }
+
+    const chromaticNote = normalizeChromaticNote(noteName);
+    if (chromaticNote) {
+      if (isStaticChromaticColors.value) {
+        return getStaticChromaticNoteColors(
+          chromaticNote,
+          octave,
+          dynamicColorConfig.value,
+          animated ? animationTime.value : undefined
+        );
+      }
+
+      const fallbackIndex = getFallbackScaleIndexForChromaticNote(
+        chromaticNote,
+        mode,
+        key
+      );
+      if (fallbackIndex !== null) {
+        return getNoteColorsByScaleIndex(
+          fallbackIndex,
+          mode,
+          key,
+          octave,
+          animated
+        );
+      }
+    }
+
+    return {
+      primary: "hsla(0, 80%, 50%, 1)",
+      accent: "hsla(180, 80%, 50%, 1)",
+      secondary: "hsla(120, 80%, 50%, 1)",
+      tertiary: "hsla(240, 80%, 50%, 1)",
+    };
+  };
+
+  const getPrimaryColorByScaleIndex = (
+    scaleIndex: number,
+    mode: MusicalMode = "major",
+    key: ChromaticNote = "C",
+    octave: number = 3
+  ): string => getNoteColorsByScaleIndex(scaleIndex, mode, key, octave, true).primary;
+
+  const getStaticPrimaryColorByScaleIndex = (
+    scaleIndex: number,
+    mode: MusicalMode = "major",
+    key: ChromaticNote = "C",
+    octave: number = 3
+  ): string =>
+    getNoteColorsByScaleIndex(scaleIndex, mode, key, octave, false).primary;
+
   const getPrimaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, true).primary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, true, key).primary;
 
-  /**
-   * Get static primary color for a note (no animation)
-   */
   const getStaticPrimaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, false).primary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, false, key).primary;
 
-  /**
-   * Get accent color for a note (used for strings/flecks)
-   */
   const getAccentColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, true).accent;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, true, key).accent;
 
-  /**
-   * Get static accent color for a note (no animation)
-   */
   const getStaticAccentColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, false).accent;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, false, key).accent;
 
-  /**
-   * Get secondary color for a note
-   */
   const getSecondaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, true).secondary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, true, key).secondary;
 
-  /**
-   * Get static secondary color for a note (no animation)
-   */
   const getStaticSecondaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, false).secondary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, false, key).secondary;
 
-  /**
-   * Get tertiary color for a note
-   */
   const getTertiaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, true).tertiary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, true, key).tertiary;
 
-  /**
-   * Get static tertiary color for a note (no animation)
-   */
   const getStaticTertiaryColor = (
     noteName: string,
     mode: MusicalMode = "major",
-    octave: number = 3
-  ): string => {
-    return getNoteColors(noteName, mode, octave, false).tertiary;
-  };
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ): string => getNoteColors(noteName, mode, octave, false, key).tertiary;
 
-  // Backward compatibility aliases
   const getStringColor = getAccentColor;
   const getFleckColor = getAccentColor;
   const getHighlightColor = getAccentColor;
 
-  /**
-   * Generate gradient string for CSS
-   */
   const getGradient = (
     noteName: string,
     mode: MusicalMode = "major",
     octave: number = 3,
-    direction: number | string = 45
+    direction: number | string = 45,
+    key: ChromaticNote = "C"
   ): string => {
-    const colors = getNoteColors(noteName, mode, octave, true);
-    // Convert numeric direction to CSS format
+    const colors = getNoteColors(noteName, mode, octave, true, key);
     const cssDirection =
       typeof direction === "number" ? `${direction}deg` : direction;
     return `linear-gradient(${cssDirection}, ${colors.primary} 60%, ${colors.accent}, ${colors.secondary}, ${colors.tertiary})`;
   };
 
-  /**
-   * Convert HSLA color to have specific alpha
-   */
   const withAlpha = (color: string, alpha: number): string => {
-    // Convert hsla(h, s%, l%, a) to hsla(h, s%, l%, newAlpha)
     if (color.startsWith("hsla(")) {
       return color.replace(/,\s*[\d.]+\)$/, `, ${alpha})`);
     }
-    // Convert hsl(h, s%, l%) to hsla(h, s%, l%, alpha)
+
     if (color.startsWith("hsl(")) {
       return color.replace("hsl(", "hsla(").replace(")", `, ${alpha})`);
     }
+
     return color;
   };
 
-  /**
-   * Check if dynamic colors are enabled
-   */
-  const isDynamicColorsEnabled = computed(() => true); // Always true in unified system
+  const isDynamicColorsEnabled = computed(() => true);
 
-  /**
-   * Get color preview for all notes
-   */
-  const getColorPreview = (mode: MusicalMode = "major", octave: number = 3) => {
-    const config = dynamicColorConfig.value;
-    const notes = config.chromaticMapping ? CHROMATIC_NOTES : SOLFEGE_NOTES;
+  const getColorPreview = (
+    mode: MusicalMode = "major",
+    octave: number = 3,
+    key: ChromaticNote = "C"
+  ) => {
+    const scale = getScaleForMode(mode);
 
-    return notes.map((noteName: string, index: number) => ({
-      name: noteName,
+    return scale.solfege.map((note, index) => ({
+      name: note.name,
       index,
-      colors: getNoteColors(noteName, mode, octave, false), // Static preview
+      chromaticNote: getChromaticNoteForScaleIndex(index, mode, key),
+      colors: getNoteColorsByScaleIndex(index, mode, key, octave, false),
     }));
   };
 
-  /**
-   * Create glassmorphism background effect
-   */
   const createGlassmorphBackground = (
     color: string,
     opacity: number = 0.4
   ): string => {
-    const color1 = withAlpha(color, opacity * 1.425); // 57% of base opacity
-    const color2 = withAlpha(color, opacity * 0.15); // 6% of base opacity
+    const color1 = withAlpha(color, opacity * 1.425);
+    const color2 = withAlpha(color, opacity * 0.15);
     return `radial-gradient(84.35% 70.19% at 50% 38.11%, ${color1}, ${color2})`;
   };
 
-  /**
-   * Create glassmorphism box shadow effect
-   */
   const createGlassmorphShadow = (color: string): string => {
     const shadowColor = withAlpha(color, 0.09);
     return `hsla(0, 0%, 100%, 0.1) 0px 1px 0px 0px inset, hsla(0, 0%, 0%, 0.4) 0px 30px 50px 0px, ${shadowColor} 0px 4px 24px 0px, hsla(0, 0%, 100%, 0.06) 0px 0px 0px 1px inset`;
   };
 
-  /**
-   * Create chord-specific glassmorphism background using gradient of multiple colors
-   */
   const createChordGlassmorphBackground = (
     colors: string[],
     opacity: number = 0.4
   ): string => {
-    if (colors.length === 0) return "rgba(255, 255, 255, 0.1)";
+    if (colors.length === 0) {
+      return "rgba(255, 255, 255, 0.1)";
+    }
 
     if (colors.length === 1) {
       return createGlassmorphBackground(colors[0], opacity);
     }
 
-    // Create a blended linear gradient for multiple colors
     const gradientColors = colors.map((color) => withAlpha(color, opacity));
     const gradientColorsLight = colors.map((color) =>
       withAlpha(color, opacity * 0.15)
     );
 
-    return `linear-gradient(135deg, 
-      ${gradientColors.join(", ")}, 
-      ${gradientColorsLight.join(", ")})`;
+    return `linear-gradient(135deg, ${gradientColors.join(
+      ", "
+    )}, ${gradientColorsLight.join(", ")})`;
   };
 
-  /**
-   * Create chord-specific glassmorphism shadow
-   */
   const createChordGlassmorphShadow = (colors: string[]): string => {
-    if (colors.length === 0) return createGlassmorphShadow("#ffffff");
+    if (colors.length === 0) {
+      return createGlassmorphShadow("#ffffff");
+    }
 
-    // Use the first color for the shadow, or blend if multiple
-    const shadowColor = colors.length >= 1 ? colors[0] : "#ffffff";
-    return createGlassmorphShadow(shadowColor);
+    return createGlassmorphShadow(colors[0]);
   };
 
-  /**
-   * Create interval-specific glassmorphism background
-   */
   const createIntervalGlassmorphBackground = (
     fromColor: string,
     toColor: string,
@@ -440,148 +509,129 @@ export function useColorSystem() {
     return `linear-gradient(90deg, ${fromColorAlpha}, ${toColorAlpha})`;
   };
 
-  /**
-   * Create gradient from multiple colors
-   */
   const createGradient = (
     colors: string[],
     direction: string = "135deg"
   ): string => {
-    if (colors.length === 1) return colors[0];
+    if (colors.length === 1) {
+      return colors[0];
+    }
+
     return `linear-gradient(${direction}, ${colors.join(", ")})`;
   };
 
-  /**
-   * Create conical gradient from multiple colors
-   */
   const createConicGradient = (
     colors: string[],
     startAngle: string = "0deg"
   ): string => {
-    if (colors.length === 1) return colors[0];
+    if (colors.length === 1) {
+      return colors[0];
+    }
+
     return `conic-gradient(from ${startAngle}, ${colors.join(", ")})`;
   };
 
-  /**
-   * Create conical glassmorphism background effect
-   */
   const createConicGlassmorphBackground = (
     color: string,
     opacity: number = 0.4,
     startAngle: string = "0deg"
   ): string => {
-    const color1 = withAlpha(color, opacity * 1.425); // 57% of base opacity
-    const color2 = withAlpha(color, opacity * 0.15); // 6% of base opacity
-    const color3 = withAlpha(color, opacity * 0.8); // 32% of base opacity
+    const color1 = withAlpha(color, opacity * 1.425);
+    const color2 = withAlpha(color, opacity * 0.15);
+    const color3 = withAlpha(color, opacity * 0.8);
     return `conic-gradient(from ${startAngle}, ${color1}, ${color2}, ${color3}, ${color1})`;
   };
 
-  /**
-   * Helper: Normalize an index within a base using positive modulo
-   */
-  const normalizeIndex = (index: number, base: number): number => {
-    return ((index % base) + base) % base;
-  };
-
-  /**
-   * Resolve solfege name from various inputs.
-   * - inputType 'scaleIndex': 0-6 (may be any integer; wraps mod 7)
-   * - inputType 'solfegeIndex': 1-7 (may be any integer; wraps so 7->Do, 8->Re, -1->Ti, etc.)
-   * - inputType 'solfegeName': a string like 'Do', 'Re', etc. (case-insensitive)
-   */
   type SolfegeInputType = "scaleIndex" | "solfegeIndex" | "solfegeName";
 
   const resolveSolfegeName = (
     input: number | string,
-    inputType: SolfegeInputType = "scaleIndex"
+    inputType: SolfegeInputType = "scaleIndex",
+    mode: MusicalMode = "major"
   ): string => {
+    const scale = getScaleForMode(mode);
+
     if (inputType === "solfegeName") {
       const name = String(input).replace("'", "");
-      const match = SOLFEGE_NOTES.find(
-        (n) => n.toLowerCase() === name.toLowerCase()
+      const match = scale.solfege.find(
+        (note) => note.name.toLowerCase() === name.toLowerCase()
       );
-      return match || SOLFEGE_NOTES[0];
+      return match?.name || scale.solfege[0]?.name || ALL_SOLFEGE_NOTES[0];
     }
 
     if (inputType === "solfegeIndex") {
-      // 1-7 scale; wrap and map back to 1-7, then to 0-6
-      const normalizedOneToSeven = normalizeIndex(Number(input) - 1, 7) + 1;
-      const zeroToSix = normalizedOneToSeven - 1;
-      return SOLFEGE_NOTES[zeroToSix] || SOLFEGE_NOTES[0];
+      const normalizedOneBased =
+        normalizeIndex(Number(input) - 1, scale.degreeCount) + 1;
+      return (
+        scale.solfege[normalizedOneBased - 1]?.name ||
+        scale.solfege[0]?.name ||
+        ALL_SOLFEGE_NOTES[0]
+      );
     }
 
-    // Default: scaleIndex (0-6), but allow any integer and wrap
-    const zeroToSix = normalizeIndex(Number(input), 7);
-    return SOLFEGE_NOTES[zeroToSix] || SOLFEGE_NOTES[0];
+    const normalizedIndex = normalizeIndex(Number(input), scale.degreeCount);
+    return (
+      scale.solfege[normalizedIndex]?.name ||
+      scale.solfege[0]?.name ||
+      ALL_SOLFEGE_NOTES[0]
+    );
   };
 
-  /**
-   * Convenience: return static primary color from any solfege input format
-   */
   const getStaticPrimaryColorFromSolfegeInput = (
     input: number | string,
     inputType: SolfegeInputType = "scaleIndex",
     mode: MusicalMode = "major",
-    octave: number = 3
+    octave: number = 3,
+    key: ChromaticNote = "C"
   ): string => {
-    const solfegeName = resolveSolfegeName(input, inputType);
-    return getStaticPrimaryColor(solfegeName, mode, octave);
+    const solfegeName = resolveSolfegeName(input, inputType, mode);
+    return getStaticPrimaryColor(solfegeName, mode, octave, key);
   };
 
-  /**
-   * Expose normalized mapping info for external use
-   */
   const getSolfegeMappingInfo = (
     input: number | string,
-    inputType: SolfegeInputType = "scaleIndex"
+    inputType: SolfegeInputType = "scaleIndex",
+    mode: MusicalMode = "major"
   ) => {
-    const name = resolveSolfegeName(input, inputType);
-    const zeroToSix = SOLFEGE_NOTES.indexOf(name);
-    const oneToSeven = zeroToSix + 1;
+    const scale = getScaleForMode(mode);
+    const name = resolveSolfegeName(input, inputType, mode);
+    const scaleIndex = scale.solfege.findIndex((note) => note.name === name);
     return {
       solfegeName: name,
-      scaleIndex: zeroToSix, // 0-6
-      solfegeIndex: oneToSeven, // 1-7
+      scaleIndex,
+      solfegeIndex: scaleIndex + 1,
     };
   };
 
-  /**
-   * Create chord-specific conical glassmorphism background using gradient of multiple colors
-   */
   const createChordConicGlassmorphBackground = (
     colors: string[],
     opacity: number = 0.4,
     startAngle: string = "0deg"
   ): string => {
-    if (colors.length === 0) return "rgba(255, 255, 255, 0.1)";
+    if (colors.length === 0) {
+      return "rgba(255, 255, 255, 0.1)";
+    }
 
     if (colors.length === 1) {
       return createConicGlassmorphBackground(colors[0], opacity, startAngle);
     }
 
-    // Create a blended conical gradient for multiple colors
     const gradientColors = colors.map((color) => withAlpha(color, opacity));
     const gradientColorsLight = colors.map((color) =>
       withAlpha(color, opacity * 0.15)
     );
-
-    // Interleave full and light colors for better visual effect
     const interleavedColors: string[] = [];
-    for (let i = 0; i < colors.length; i++) {
-      interleavedColors.push(gradientColors[i]);
-      interleavedColors.push(gradientColorsLight[i]);
+
+    for (let index = 0; index < colors.length; index++) {
+      interleavedColors.push(gradientColors[index]);
+      interleavedColors.push(gradientColorsLight[index]);
     }
-    // Complete the circle by adding the first color again
+
     interleavedColors.push(gradientColors[0]);
 
-    return `conic-gradient(from ${startAngle}, ${interleavedColors.join(
-      ", "
-    )})`;
+    return `conic-gradient(from ${startAngle}, ${interleavedColors.join(", ")})`;
   };
 
-  /**
-   * Create interval-specific conical glassmorphism background
-   */
   const createIntervalConicGlassmorphBackground = (
     fromColor: string,
     toColor: string,
@@ -596,35 +646,30 @@ export function useColorSystem() {
     return `conic-gradient(from ${startAngle}, ${fromColorAlpha}, ${toColorLight}, ${toColorAlpha}, ${fromColorLight}, ${fromColorAlpha})`;
   };
 
-  /**
-   * Generate conical gradient string for CSS
-   */
   const getConicGradient = (
     noteName: string,
     mode: MusicalMode = "major",
     octave: number = 3,
-    startAngle: number | string = 0
+    startAngle: number | string = 0,
+    key: ChromaticNote = "C"
   ): string => {
-    const colors = getNoteColors(noteName, mode, octave, true);
-    // Convert numeric angle to CSS format
+    const colors = getNoteColors(noteName, mode, octave, true, key);
     const cssAngle =
       typeof startAngle === "number" ? `${startAngle}deg` : startAngle;
     return `conic-gradient(from ${cssAngle}, ${colors.primary}, ${colors.accent}, ${colors.secondary}, ${colors.tertiary}, ${colors.primary})`;
   };
 
-  /**
-   * Helper function to adjust color brightness and saturation
-   */
   const adjustColorHSL = (
     color: string,
     brightness: number = 1,
     saturation: number = 1
   ): string => {
-    // Parse HSLA color
     const hslaMatch = color.match(
       /hsla?\((\d+),\s*(\d+)%,\s*(\d+)%(?:,\s*([\d.]+))?\)/
     );
-    if (!hslaMatch) return color;
+    if (!hslaMatch) {
+      return color;
+    }
 
     const [, h, s, l, a = "1"] = hslaMatch;
     const adjustedS = Math.max(0, Math.min(100, parseFloat(s) * saturation));
@@ -633,12 +678,10 @@ export function useColorSystem() {
     return `hsla(${h}, ${adjustedS}%, ${adjustedL}%, ${a})`;
   };
 
-  /**
-   * Get key background based on color mode and configuration
-   */
   const getKeyBackground = (
-    solfegeName: string,
-    mode: "major" | "minor",
+    scaleIndex: number,
+    mode: MusicalMode,
+    key: ChromaticNote,
     octave: number,
     colorMode: "colored" | "monochrome" | "glassmorphism",
     isAccidental: boolean,
@@ -655,7 +698,6 @@ export function useColorSystem() {
     } = config;
 
     if (colorMode === "monochrome") {
-      // Monochrome: white for accidentals, black for naturals
       const baseColor = isAccidental
         ? "hsla(0, 0%, 100%, 1)"
         : "hsla(0, 0%, 10%, 1)";
@@ -670,30 +712,20 @@ export function useColorSystem() {
       };
     }
 
-    // Get primary color for colored and glassmorphism modes
-    const primaryColor = getStaticPrimaryColor(solfegeName, mode, octave);
-    if (!primaryColor) {
-      // Fallback color
-      const fallback = "hsla(200, 70%, 50%, 1)";
-      return {
-        background: fallback,
-        primaryColor: fallback,
-      };
-    }
+    const primaryColor = getStaticPrimaryColorByScaleIndex(
+      scaleIndex,
+      mode,
+      key,
+      octave
+    );
 
     if (colorMode === "glassmorphism") {
-      // Glassmorphism mode
-      const glassBg = createGlassmorphBackground(
-        primaryColor,
-        glassmorphOpacity
-      );
       return {
-        background: glassBg || `hsla(200, 70%, 50%, ${glassmorphOpacity})`,
+        background: createGlassmorphBackground(primaryColor, glassmorphOpacity),
         primaryColor,
       };
     }
 
-    // Colored mode
     const adjustedColor = adjustColorHSL(
       primaryColor,
       keyBrightness,
@@ -705,82 +737,53 @@ export function useColorSystem() {
     };
   };
 
-  /**
-   * Get text color for key labels
-   */
   const getKeyTextColor = (
     colorMode: "colored" | "monochrome" | "glassmorphism",
     isAccidental: boolean
   ): string => {
     if (colorMode === "monochrome") {
-      // Monochrome: opposite of key color
       return isAccidental ? "text-black" : "text-white";
     }
 
-    // Colored and glassmorphism: black for accidentals, white for naturals
     return isAccidental ? "text-black" : "text-white";
   };
 
   return {
-    // Core color functions
     getNoteColors,
+    getNoteColorsByScaleIndex,
     getPrimaryColor,
+    getPrimaryColorByScaleIndex,
     getAccentColor,
     getSecondaryColor,
     getTertiaryColor,
-
-    // Static color functions (no animation)
     getStaticPrimaryColor,
+    getStaticPrimaryColorByScaleIndex,
     getStaticAccentColor,
     getStaticSecondaryColor,
     getStaticTertiaryColor,
-
-    // Backward compatibility aliases
     getStringColor,
     getFleckColor,
     getHighlightColor,
-
-    // Utility functions
     getGradient,
     getConicGradient,
     withAlpha,
     createGradient,
     createConicGradient,
-
-    // Solfege helpers
     resolveSolfegeName,
     getStaticPrimaryColorFromSolfegeInput,
     getSolfegeMappingInfo,
-
-    // Glassmorphism functions
     createGlassmorphBackground,
     createGlassmorphShadow,
     createChordGlassmorphBackground,
     createChordGlassmorphShadow,
     createIntervalGlassmorphBackground,
-
-    // Conical glassmorphism functions
     createConicGlassmorphBackground,
     createChordConicGlassmorphBackground,
     createIntervalConicGlassmorphBackground,
-
-    // Key styling functions
-    adjustColorHSL,
+    getColorPreview,
     getKeyBackground,
     getKeyTextColor,
-
-    // State
     isDynamicColorsEnabled,
-
-    // Preview function
-    getColorPreview,
-
-    // Animation time for external use
-    animationTime: computed(() => animationTime.value),
+    isStaticChromaticColors,
   };
-}
-
-// Export cleanup function for app-level cleanup
-export function cleanupColorSystem() {
-  stopGlobalAnimation();
 }

--- a/src/composables/useKeyboardControls.ts
+++ b/src/composables/useKeyboardControls.ts
@@ -14,8 +14,63 @@ interface KeyboardMapping {
   [key: string]: {
     solfegeIndex: number;
     octave: number;
+    label: string;
   };
 }
+
+const KEY_ROWS = [
+  {
+    octaveOffset: 1,
+    keys: [
+      { code: "Digit1", label: "1" },
+      { code: "Digit2", label: "2" },
+      { code: "Digit3", label: "3" },
+      { code: "Digit4", label: "4" },
+      { code: "Digit5", label: "5" },
+      { code: "Digit6", label: "6" },
+      { code: "Digit7", label: "7" },
+      { code: "Digit8", label: "8" },
+      { code: "Digit9", label: "9" },
+      { code: "Digit0", label: "0" },
+      { code: "Minus", label: "-" },
+      { code: "Equal", label: "=" },
+    ],
+  },
+  {
+    octaveOffset: 0,
+    keys: [
+      { code: "KeyQ", label: "Q" },
+      { code: "KeyW", label: "W" },
+      { code: "KeyE", label: "E" },
+      { code: "KeyR", label: "R" },
+      { code: "KeyT", label: "T" },
+      { code: "KeyY", label: "Y" },
+      { code: "KeyU", label: "U" },
+      { code: "KeyI", label: "I" },
+      { code: "KeyO", label: "O" },
+      { code: "KeyP", label: "P" },
+      { code: "BracketLeft", label: "[" },
+      { code: "BracketRight", label: "]" },
+    ],
+  },
+  {
+    octaveOffset: -1,
+    keys: [
+      { code: "KeyA", label: "A" },
+      { code: "KeyS", label: "S" },
+      { code: "KeyD", label: "D" },
+      { code: "KeyF", label: "F" },
+      { code: "KeyG", label: "G" },
+      { code: "KeyH", label: "H" },
+      { code: "KeyJ", label: "J" },
+      { code: "KeyK", label: "K" },
+      { code: "KeyL", label: "L" },
+      { code: "Semicolon", label: ";" },
+      { code: "Quote", label: "'" },
+      { code: "Backslash", label: "\\" },
+    ],
+  },
+] as const;
 
 /**
  * Composable for handling keyboard controls for solfege notes
@@ -30,39 +85,26 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
   // Track keyboard-triggered notes separately from mouse-triggered notes
   const keyboardNoteIds = ref<Map<string, string>>(new Map());
 
-  // Dynamic keyboard mapping for solfege notes across 3 octaves
-  // Top row (qwertyu) -> Above main octave
-  // Middle row (asdfghj) -> Main octave
-  // Bottom row (zxcvbnm) -> Below main octave
   const getKeyboardMapping = (): KeyboardMapping => {
-    return {
-      // Above main octave - Top row
-      q: { solfegeIndex: 0, octave: mainOctave.value + 1 },
-      w: { solfegeIndex: 1, octave: mainOctave.value + 1 },
-      e: { solfegeIndex: 2, octave: mainOctave.value + 1 },
-      r: { solfegeIndex: 3, octave: mainOctave.value + 1 },
-      t: { solfegeIndex: 4, octave: mainOctave.value + 1 },
-      y: { solfegeIndex: 5, octave: mainOctave.value + 1 },
-      u: { solfegeIndex: 6, octave: mainOctave.value + 1 },
+    const degreeCount = musicStore.currentScale.degreeCount;
+    const mapping: KeyboardMapping = {};
 
-      // Main octave - Middle row
-      a: { solfegeIndex: 0, octave: mainOctave.value },
-      s: { solfegeIndex: 1, octave: mainOctave.value },
-      d: { solfegeIndex: 2, octave: mainOctave.value },
-      f: { solfegeIndex: 3, octave: mainOctave.value },
-      g: { solfegeIndex: 4, octave: mainOctave.value },
-      h: { solfegeIndex: 5, octave: mainOctave.value },
-      j: { solfegeIndex: 6, octave: mainOctave.value },
+    KEY_ROWS.forEach((row) => {
+      const octave = mainOctave.value + row.octaveOffset;
+      if (octave < 1 || octave > 8) {
+        return;
+      }
 
-      // Below main octave - Bottom row
-      z: { solfegeIndex: 0, octave: mainOctave.value - 1 },
-      x: { solfegeIndex: 1, octave: mainOctave.value - 1 },
-      c: { solfegeIndex: 2, octave: mainOctave.value - 1 },
-      v: { solfegeIndex: 3, octave: mainOctave.value - 1 },
-      b: { solfegeIndex: 4, octave: mainOctave.value - 1 },
-      n: { solfegeIndex: 5, octave: mainOctave.value - 1 },
-      m: { solfegeIndex: 6, octave: mainOctave.value - 1 },
-    };
+      row.keys.slice(0, degreeCount).forEach((key, index) => {
+        mapping[key.code] = {
+          solfegeIndex: index,
+          octave,
+          label: key.label,
+        };
+      });
+    });
+
+    return mapping;
   };
 
   /**
@@ -81,7 +123,7 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
         noteMapping.solfegeIndex === solfegeIndex &&
         noteMapping.octave === octave
       ) {
-        return key.toUpperCase(); // Return uppercase for display
+        return noteMapping.label;
       }
     }
 
@@ -105,9 +147,9 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
       return;
     }
 
-    const key = event.key; // Don't convert to lowercase to preserve shift state
+    const key = event.code;
 
-    if (key === "Backspace" || key === "Delete") {
+    if (event.key === "Backspace" || event.key === "Delete") {
       event.preventDefault();
       patternsStore.removeLastFromCurrentSketch();
       return;
@@ -120,16 +162,13 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
 
     // Get current keyboard mapping
     const keyboardMapping = getKeyboardMapping();
-
-    // Check if this key is mapped to a solfege note
     if (key in keyboardMapping) {
       event.preventDefault();
       pressedKeys.value.add(key);
 
-      const { solfegeIndex, octave } =
+      const { solfegeIndex, octave, label } =
         keyboardMapping[key as keyof typeof keyboardMapping];
 
-      // Attack the note and track the note ID for this specific key
       const noteId = await musicStore.attackNoteWithOctave(
         solfegeIndex,
         octave
@@ -140,7 +179,7 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
         // Dispatch custom event for visual feedback
         window.dispatchEvent(
           new CustomEvent("keyboard-note-pressed", {
-            detail: { solfegeIndex, octave, key },
+            detail: { solfegeIndex, octave, key: label },
           })
         );
       }
@@ -148,7 +187,7 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
   };
 
   const handleKeyUp = (event: KeyboardEvent) => {
-    const key = event.key; // Don't convert to lowercase to preserve shift state
+    const key = event.code;
 
     if (pressedKeys.value.has(key)) {
       pressedKeys.value.delete(key);
@@ -162,11 +201,15 @@ export function useKeyboardControls(mainOctave: Ref<number>) {
         // Dispatch custom event for visual feedback
         window.dispatchEvent(
           new CustomEvent("keyboard-note-released", {
-            detail: { key },
+            detail: { key: keyboardMappingLabel(key) },
           })
         );
       }
     }
+  };
+
+  const keyboardMappingLabel = (code: string): string => {
+    return getKeyboardMapping()[code]?.label ?? code;
   };
 
   // Handle window blur to release all keyboard notes (safety mechanism)

--- a/src/composables/useSolfegeInteraction.ts
+++ b/src/composables/useSolfegeInteraction.ts
@@ -53,7 +53,13 @@ export function useSolfegeInteraction() {
       if (isDynamicColorsEnabled.value) {
         animationFrame.value; // This triggers re-computation on every frame
       }
-      return getGradient(noteName, mode);
+      return getGradient(
+        noteName,
+        mode,
+        3,
+        45,
+        musicStore.currentKey as ChromaticNote
+      );
     };
   });
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -6,14 +6,36 @@
 // Notes
 export { CHROMATIC_NOTES } from "./notes";
 export type { ChromaticNote } from "./notes";
-export { SOLFEGE_NOTES } from "./notes";
+export { SOLFEGE_NOTES, ALL_SOLFEGE_NOTES } from "./notes";
 
 // Solfege
-export { MAJOR_SOLFEGE, MINOR_SOLFEGE } from "./solfege";
+export {
+  INTERVAL_IDENTITY_MAP,
+  INTERVAL_TO_SOLFEGE,
+  MAJOR_SOLFEGE,
+  MINOR_SOLFEGE,
+  MOVABLE_DO_SOLFEGE_NOTES,
+  createSolfegeData,
+  getSolfegeLabelForInterval,
+} from "./solfege";
 export type { SolfegeData } from "./solfege";
 
+// Modes
+export {
+  MODE_DEFINITIONS,
+  MODE_OPTIONS,
+  MODE_ORDER,
+  getModeDefinition,
+} from "./modes";
+
 // Scales
-export { MAJOR_SCALE, MINOR_SCALE } from "./scales";
+export {
+  MAJOR_SCALE,
+  MINOR_SCALE,
+  SCALE_MAP,
+  getScaleForMode,
+  getSolfegeNameForMode,
+} from "./scales";
 export type { Scale } from "./scales";
 
 // Patterns - updated exports

--- a/src/data/modes.ts
+++ b/src/data/modes.ts
@@ -1,0 +1,146 @@
+import type { ModeDefinition, MusicalMode } from "@/types/music";
+
+export const MODE_ORDER: MusicalMode[] = [
+  "major",
+  "minor",
+  "dorian",
+  "phrygian",
+  "lydian",
+  "mixolydian",
+  "locrian",
+  "harmonic minor",
+  "melodic minor",
+  "major pentatonic",
+  "minor pentatonic",
+  "major blues",
+  "minor blues",
+  "chromatic",
+];
+
+export const MODE_DEFINITIONS: Record<MusicalMode, ModeDefinition> = {
+  major: {
+    mode: "major",
+    label: "Major",
+    tonalName: "major",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  minor: {
+    mode: "minor",
+    label: "Minor",
+    tonalName: "minor",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  dorian: {
+    mode: "dorian",
+    label: "Dorian",
+    tonalName: "dorian",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  phrygian: {
+    mode: "phrygian",
+    label: "Phrygian",
+    tonalName: "phrygian",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  lydian: {
+    mode: "lydian",
+    label: "Lydian",
+    tonalName: "lydian",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  mixolydian: {
+    mode: "mixolydian",
+    label: "Mixolydian",
+    tonalName: "mixolydian",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  locrian: {
+    mode: "locrian",
+    label: "Locrian",
+    tonalName: "locrian",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  "harmonic minor": {
+    mode: "harmonic minor",
+    label: "Harmonic Minor",
+    tonalName: "harmonic minor",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  "melodic minor": {
+    mode: "melodic minor",
+    label: "Melodic Minor",
+    tonalName: "melodic minor",
+    family: "heptatonic",
+    degreeCount: 7,
+  },
+  "major pentatonic": {
+    mode: "major pentatonic",
+    label: "Major Pentatonic",
+    tonalName: "major pentatonic",
+    family: "pentatonic",
+    degreeCount: 5,
+  },
+  "minor pentatonic": {
+    mode: "minor pentatonic",
+    label: "Minor Pentatonic",
+    tonalName: "minor pentatonic",
+    family: "pentatonic",
+    degreeCount: 5,
+  },
+  "major blues": {
+    mode: "major blues",
+    label: "Major Blues",
+    tonalName: "major blues",
+    family: "hexatonic",
+    degreeCount: 6,
+  },
+  "minor blues": {
+    mode: "minor blues",
+    label: "Minor Blues",
+    tonalName: "minor blues",
+    family: "hexatonic",
+    degreeCount: 6,
+  },
+  chromatic: {
+    mode: "chromatic",
+    label: "Chromatic",
+    tonalName: "chromatic",
+    family: "chromatic",
+    degreeCount: 12,
+  },
+};
+
+const MODE_OPTION_COLORS: Record<MusicalMode, string> = {
+  major: "hsl(22, 60%, 72%)",
+  minor: "hsl(210, 48%, 72%)",
+  dorian: "hsl(164, 40%, 68%)",
+  phrygian: "hsl(350, 42%, 72%)",
+  lydian: "hsl(56, 62%, 72%)",
+  mixolydian: "hsl(132, 42%, 70%)",
+  locrian: "hsl(280, 34%, 72%)",
+  "harmonic minor": "hsl(328, 48%, 72%)",
+  "melodic minor": "hsl(188, 42%, 72%)",
+  "major pentatonic": "hsl(40, 68%, 72%)",
+  "minor pentatonic": "hsl(230, 48%, 72%)",
+  "major blues": "hsl(20, 72%, 68%)",
+  "minor blues": "hsl(215, 58%, 68%)",
+  chromatic: "hsl(302, 40%, 74%)",
+};
+
+export const MODE_OPTIONS = MODE_ORDER.map((mode) => ({
+  label: MODE_DEFINITIONS[mode].label,
+  value: mode,
+  color: MODE_OPTION_COLORS[mode],
+}));
+
+export function getModeDefinition(mode: MusicalMode): ModeDefinition {
+  return MODE_DEFINITIONS[mode];
+}

--- a/src/data/musicData.ts
+++ b/src/data/musicData.ts
@@ -5,9 +5,36 @@
  */
 
 // Import from modular files
-export { CHROMATIC_NOTES } from "./notes";
-export { MAJOR_SOLFEGE, MINOR_SOLFEGE } from "./solfege";
-export { MAJOR_SCALE, MINOR_SCALE } from "./scales";
+export { CHROMATIC_NOTES, SOLFEGE_NOTES, ALL_SOLFEGE_NOTES } from "./notes";
+export {
+  INTERVAL_IDENTITY_MAP,
+  INTERVAL_TO_SOLFEGE,
+  MAJOR_SOLFEGE,
+  MINOR_SOLFEGE,
+  MOVABLE_DO_SOLFEGE_NOTES,
+  createSolfegeData,
+  getSolfegeLabelForInterval,
+} from "./solfege";
+export {
+  MODE_DEFINITIONS,
+  MODE_OPTIONS,
+  MODE_ORDER,
+  getModeDefinition,
+} from "./modes";
+export {
+  MAJOR_SCALE,
+  MINOR_SCALE,
+  SCALE_MAP,
+  getScaleForMode,
+  getSolfegeNameForMode,
+} from "./scales";
 
 // Re-export types for backward compatibility
-export type { SolfegeData, Scale, ChromaticNote } from "@/types/music";
+export type {
+  ChromaticNote,
+  ModeDefinition,
+  MusicalMode,
+  MusicalModeFamily,
+  Scale,
+  SolfegeData,
+} from "@/types/music";

--- a/src/data/notes.ts
+++ b/src/data/notes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ChromaticNote } from "@/types/music";
+import { MOVABLE_DO_SOLFEGE_NOTES } from "./solfege";
 
 // Re-export types for backward compatibility
 export type { ChromaticNote };
@@ -27,3 +28,4 @@ export const CHROMATIC_NOTES: ChromaticNote[] = [
 ];
 
 export const SOLFEGE_NOTES = ["Do", "Re", "Mi", "Fa", "Sol", "La", "Ti"];
+export const ALL_SOLFEGE_NOTES = MOVABLE_DO_SOLFEGE_NOTES;

--- a/src/data/scales.ts
+++ b/src/data/scales.ts
@@ -1,48 +1,85 @@
 /**
- * Enhanced Musical Scales Data using Tonal.js
- * Leverages Tonal.js for accurate scale generation and validation
+ * Musical scales generated from the centralized mode catalog and Tonal.js.
  */
 
-import { Scale as TonalScale, Interval } from "@tonaljs/tonal";
-import type { Scale } from "@/types/music";
-import { MAJOR_SOLFEGE, MINOR_SOLFEGE } from "./solfege";
+import { Interval, Scale as TonalScale } from "@tonaljs/tonal";
+import type { MusicalMode, Scale } from "@/types/music";
+import { MODE_DEFINITIONS, MODE_ORDER } from "./modes";
+import { createSolfegeData } from "./solfege";
 
-// Re-export types for backward compatibility
 export type { Scale };
 
-/**
- * Generate scale intervals using Tonal.js
- */
-function generateScaleIntervals(scaleType: string): number[] {
+function fallbackScale(mode: MusicalMode): Scale {
+  const definition = MODE_DEFINITIONS[mode];
+  const intervalNames =
+    mode === "major"
+      ? ["1P", "2M", "3M", "4P", "5P", "6M", "7M"]
+      : mode === "minor"
+        ? ["1P", "2M", "3m", "4P", "5P", "6m", "7m"]
+        : ["1P"];
+  const intervals = intervalNames.map((intervalName) => {
+    const semitones = Interval.semitones(intervalName);
+    return semitones ?? 0;
+  });
+
+  return {
+    name: definition.label,
+    mode,
+    tonalName: definition.tonalName,
+    family: definition.family,
+    degreeCount: intervalNames.length,
+    intervalNames,
+    intervals,
+    solfege: createSolfegeData(intervalNames, intervals, mode),
+  };
+}
+
+function createScale(mode: MusicalMode): Scale {
+  const definition = MODE_DEFINITIONS[mode];
+
   try {
-    const scale = TonalScale.get(`C ${scaleType}`);
-    return scale.intervals.map((interval) => {
-      const semitones = Interval.semitones(interval);
+    const scale = TonalScale.get(`C ${definition.tonalName}`);
+    const intervalNames = scale.intervals.length
+      ? scale.intervals
+      : fallbackScale(mode).intervalNames;
+    const intervals = intervalNames.map((intervalName) => {
+      const semitones = Interval.semitones(intervalName);
       return semitones ?? 0;
     });
-  } catch (error) {
-    return scaleType === "major"
-      ? [0, 2, 4, 5, 7, 9, 11, 12]
-      : [0, 2, 3, 5, 7, 8, 10, 12];
+
+    return {
+      name: definition.label,
+      mode,
+      tonalName: definition.tonalName,
+      family: definition.family,
+      degreeCount: intervalNames.length,
+      intervalNames,
+      intervals,
+      solfege: createSolfegeData(intervalNames, intervals, mode),
+    };
+  } catch {
+    return fallbackScale(mode);
   }
 }
 
-/**
- * Enhanced Major scale definition using Tonal.js
- * W-W-H-W-W-W-H pattern + octave (validated by Tonal.js)
- */
-export const MAJOR_SCALE: Scale = {
-  name: "Major",
-  intervals: generateScaleIntervals("major"),
-  solfege: MAJOR_SOLFEGE,
-};
+export const SCALE_MAP: Record<MusicalMode, Scale> = MODE_ORDER.reduce(
+  (map, mode) => {
+    map[mode] = createScale(mode);
+    return map;
+  },
+  {} as Record<MusicalMode, Scale>
+);
 
-/**
- * Enhanced Minor scale definition using Tonal.js
- * W-H-W-W-H-W-W pattern (natural minor) + octave (validated by Tonal.js)
- */
-export const MINOR_SCALE: Scale = {
-  name: "Minor",
-  intervals: generateScaleIntervals("minor"),
-  solfege: MINOR_SOLFEGE,
-};
+export const MAJOR_SCALE = SCALE_MAP.major;
+export const MINOR_SCALE = SCALE_MAP.minor;
+
+export function getScaleForMode(mode: MusicalMode): Scale {
+  return SCALE_MAP[mode] ?? MAJOR_SCALE;
+}
+
+export function getSolfegeNameForMode(
+  mode: MusicalMode,
+  scaleIndex: number
+): string {
+  return getScaleForMode(mode).solfege[scaleIndex]?.name ?? "Do";
+}

--- a/src/data/solfege.ts
+++ b/src/data/solfege.ts
@@ -1,133 +1,295 @@
 /**
  * Solfege Data
- * Contains solfege note definitions for major and minor scales
+ * Interval-driven movable-do identities with major/minor legacy overrides.
  */
 
-import type { SolfegeData } from "@/types/music";
+import type { MusicalMode, SolfegeData } from "@/types/music";
 
-// Re-export types for backward compatibility
 export type { SolfegeData };
 
-/**
- * Major scale solfege data with emotional descriptions and visual properties
- */
-export const MAJOR_SOLFEGE: SolfegeData[] = [
-  {
+type SolfegeIdentity = Omit<SolfegeData, "number" | "intervalName" | "semitones">;
+
+export const INTERVAL_TO_SOLFEGE: Record<string, string> = {
+  "1P": "Do",
+  "2m": "Ra",
+  "2M": "Re",
+  "3m": "Me",
+  "3M": "Mi",
+  "4P": "Fa",
+  "4A": "Fi",
+  "5d": "Se",
+  "5P": "Sol",
+  "6m": "Le",
+  "6M": "La",
+  "7m": "Te",
+  "7M": "Ti",
+};
+
+export const MOVABLE_DO_SOLFEGE_NOTES = [
+  "Do",
+  "Ra",
+  "Re",
+  "Me",
+  "Mi",
+  "Fa",
+  "Fi",
+  "Se",
+  "Sol",
+  "Le",
+  "La",
+  "Te",
+  "Ti",
+];
+
+export const INTERVAL_IDENTITY_MAP: Record<string, SolfegeIdentity> = {
+  "1P": {
     name: "Do",
-    number: 1,
+    emotion: "Home, rest, stability",
+    description: "The tonic center. It makes the rest of the mode make sense.",
+    fleckShape: "circle",
+    texture: "foundation, trust, warmth from peace",
+  },
+  "2m": {
+    name: "Ra",
+    emotion: "Close friction, raw ache",
+    description: "A tight rub above home. It glows with uneasy closeness.",
+    fleckShape: "diamond",
+    texture: "grainy tension, urgent nearness",
+  },
+  "2M": {
+    name: "Re",
+    emotion: "Forward motion, stepping up",
+    description: "Movement away from home with momentum and curiosity.",
+    fleckShape: "mist",
+    texture: "hopeful lift, gentle curiosity",
+  },
+  "3m": {
+    name: "Me",
+    emotion: "Melancholy, introspection",
+    description: "A tender inward turn that darkens the tonic without breaking it.",
+    fleckShape: "diamond",
+    texture: "tender vulnerability",
+  },
+  "3M": {
+    name: "Mi",
+    emotion: "Bright, joyful optimism",
+    description: "A clear brightening that opens the mode into warmth.",
+    fleckShape: "sparkle",
+    texture: "clarity and rising joy",
+  },
+  "4P": {
+    name: "Fa",
+    emotion: "Tension, unease",
+    description: "A leaning tone that wants to fall or resolve.",
+    fleckShape: "diamond",
+    texture: "inward pull, leaning fall, yearning",
+  },
+  "4A": {
+    name: "Fi",
+    emotion: "Lift, shimmer, surprise",
+    description: "A sharpened fourth that opens a bright suspended skylight.",
+    fleckShape: "sparkle",
+    texture: "electric lift, suspended shine",
+  },
+  "5d": {
+    name: "Se",
+    emotion: "Blue strain, instability",
+    description: "A narrowed fifth that sounds split, smoky, and unresolved.",
+    fleckShape: "mist",
+    texture: "smoke, grit, bent tension",
+  },
+  "5P": {
+    name: "Sol",
+    emotion: "Strength, confidence, dominance",
+    description: "Stable and outward-facing. It gathers energy without landing home.",
+    fleckShape: "star",
+    texture: "a triumphant beacon",
+  },
+  "6m": {
+    name: "Le",
+    emotion: "Deep longing, sorrow",
+    description: "A dark reach outward, full of memory and ache.",
+    fleckShape: "mist",
+    texture: "grounded grief, ancient ache",
+  },
+  "6M": {
+    name: "La",
+    emotion: "Longing, wistfulness",
+    description: "Open yearning with tenderness and reach.",
+    fleckShape: "circle",
+    texture: "emotional openness, romantic ache",
+  },
+  "7m": {
+    name: "Te",
+    emotion: "Shadowed anticipation",
+    description: "A softer leading pull that circles the tonic instead of piercing it.",
+    fleckShape: "sparkle",
+    texture: "shadowed anticipation",
+  },
+  "7M": {
+    name: "Ti",
+    emotion: "Urgency, restlessness",
+    description: "A bright leading edge that urgently resolves upward to home.",
+    fleckShape: "sparkle",
+    texture: "spiritual tension, strong upward pull",
+  },
+};
+
+const MAJOR_INTERVAL_OVERRIDES: Record<string, SolfegeIdentity> = {
+  "1P": {
+    name: "Do",
     emotion: "Home, rest, stability",
     description: "The foundation. Complete resolution.",
     fleckShape: "circle",
     texture: "foundation, trust, warmth from peace",
   },
-  {
+  "2M": {
     name: "Re",
-    number: 2,
     emotion: "Forward motion, stepping up",
     description: "Moving away from home with purpose.",
     fleckShape: "mist",
     texture: "hopeful lift, gentle curiosity",
   },
-  {
+  "3M": {
     name: "Mi",
-    number: 3,
     emotion: "Bright, joyful optimism",
     description: "Sunny and optimistic, wants to rise.",
     fleckShape: "sparkle",
     texture: "clarity and rising joy",
   },
-  {
+  "4P": {
     name: "Fa",
-    number: 4,
     emotion: "Tension, unease",
     description: "Unstable, wants to fall back to Mi.",
     fleckShape: "diamond",
     texture: "inward pull, leaning fall, yearning",
   },
-  {
+  "5P": {
     name: "Sol",
-    number: 5,
     emotion: "Strength, confidence, dominance",
     description: "Confident and stable, but not quite home.",
     fleckShape: "star",
     texture: "a triumphant beacon",
   },
-  {
+  "6M": {
     name: "La",
-    number: 6,
     emotion: "Longing, wistfulness",
     description: "Beautiful sadness, reaching for Do.",
     fleckShape: "circle",
     texture: "emotional openness, romantic ache",
   },
-  {
+  "7M": {
     name: "Ti",
-    number: 7,
     emotion: "Urgency, restlessness",
     description: "Restless, must resolve up to Do!",
     fleckShape: "sparkle",
     texture: "spiritual tension, strong upward pull",
   },
-];
+};
 
-/**
- * Minor scale solfege data (using movable Do system)
- */
-export const MINOR_SOLFEGE: SolfegeData[] = [
-  {
+const MINOR_INTERVAL_OVERRIDES: Record<string, SolfegeIdentity> = {
+  "1P": {
     name: "Do",
-    number: 1,
     emotion: "Grounded, somber home",
     description: "Dark but stable foundation.",
     fleckShape: "circle",
     texture: "dignified stability with emotional weight",
   },
-  {
+  "2M": {
     name: "Re",
-    number: 2,
     emotion: "Gentle, uncertain step",
     description: "Cautious movement forward.",
     fleckShape: "mist",
     texture: "cautious, introverted motion",
   },
-  {
+  "3m": {
     name: "Me",
-    number: 3,
     emotion: "Melancholy, introspection",
     description: "Minor third - tender sadness.",
     fleckShape: "diamond",
     texture: "tender vulnerability",
   },
-  {
+  "4P": {
     name: "Fa",
-    number: 4,
     emotion: "Tension, yearning",
     description: "Same tension, deeper in minor.",
     fleckShape: "circle",
     texture: "a shadowed inward pull",
   },
-  {
+  "5P": {
     name: "Sol",
-    number: 5,
     emotion: "Bittersweet strength",
     description: "Strong but tinged with sadness.",
     fleckShape: "star",
     texture: "noble sorrow with resilience",
   },
-  {
+  "6m": {
     name: "Le",
-    number: 6,
     emotion: "Deep longing, sorrow",
     description: "Minor sixth - profound yearning.",
     fleckShape: "mist",
     texture: "grounded grief, ancient ache",
   },
-  {
+  "7m": {
     name: "Te",
-    number: 7,
     emotion: "Gentle leading, subdued",
     description: "Softer leading tone than Ti.",
     fleckShape: "sparkle",
     texture: "shadowed anticipation",
   },
-];
+};
+
+const MODE_IDENTITY_OVERRIDES: Partial<Record<MusicalMode, Record<string, SolfegeIdentity>>> = {
+  major: MAJOR_INTERVAL_OVERRIDES,
+  minor: MINOR_INTERVAL_OVERRIDES,
+};
+
+const C_MAJOR_INTERVAL_NAMES = ["1P", "2M", "3M", "4P", "5P", "6M", "7M"];
+const C_MAJOR_INTERVALS = [0, 2, 4, 5, 7, 9, 11];
+const C_MINOR_INTERVAL_NAMES = ["1P", "2M", "3m", "4P", "5P", "6m", "7m"];
+const C_MINOR_INTERVALS = [0, 2, 3, 5, 7, 8, 10];
+
+function getIdentityForInterval(
+  intervalName: string,
+  mode?: MusicalMode
+): SolfegeIdentity {
+  return (
+    (mode && MODE_IDENTITY_OVERRIDES[mode]?.[intervalName]) ||
+    INTERVAL_IDENTITY_MAP[intervalName] ||
+    INTERVAL_IDENTITY_MAP["1P"]
+  );
+}
+
+export function getSolfegeLabelForInterval(intervalName: string): string {
+  return INTERVAL_TO_SOLFEGE[intervalName] || INTERVAL_TO_SOLFEGE["1P"];
+}
+
+export function createSolfegeData(
+  intervalNames: string[],
+  semitoneIntervals: number[],
+  mode?: MusicalMode
+): SolfegeData[] {
+  return intervalNames.map((intervalName, index) => {
+    const identity = getIdentityForInterval(intervalName, mode);
+
+    return {
+      ...identity,
+      name: getSolfegeLabelForInterval(intervalName),
+      number: index + 1,
+      intervalName,
+      semitones: semitoneIntervals[index] ?? 0,
+    };
+  });
+}
+
+export const MAJOR_SOLFEGE = createSolfegeData(
+  C_MAJOR_INTERVAL_NAMES,
+  C_MAJOR_INTERVALS,
+  "major"
+);
+
+export const MINOR_SOLFEGE = createSolfegeData(
+  C_MINOR_INTERVAL_NAMES,
+  C_MINOR_INTERVALS,
+  "minor"
+);

--- a/src/data/visual-config-metadata.ts
+++ b/src/data/visual-config-metadata.ts
@@ -150,7 +150,7 @@ export const UNIFIED_CONFIG = {
     _meta: {
       label: "Ambient",
       icon: "🌅",
-      description: "Background lighting effects",
+      description: "Scale-aware background lighting effects",
     },
     isEnabled: {
       value: true,
@@ -161,7 +161,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Opacity Major",
+      label: "Center Opacity",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
     opacityMinor: {
@@ -169,7 +169,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Opacity Minor",
+      label: "Accent Opacity",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
     brightnessMajor: {
@@ -177,7 +177,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Brightness Major",
+      label: "Tonic Brightness",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
     brightnessMinor: {
@@ -185,7 +185,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Brightness Minor",
+      label: "Accent Brightness",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
     saturationMajor: {
@@ -193,7 +193,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Saturation Major",
+      label: "Tonic Saturation",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
     saturationMinor: {
@@ -201,7 +201,7 @@ export const UNIFIED_CONFIG = {
       min: 0,
       max: 1,
       step: 0.05,
-      label: "Saturation Minor",
+      label: "Accent Saturation",
       format: (v: number) => `${(v * 100).toFixed(0)}%`,
     },
   },
@@ -430,7 +430,7 @@ export const UNIFIED_CONFIG = {
     },
     chromaticMapping: {
       value: false,
-      label: "Chromatic Mapping (12 notes vs 7 solfège)",
+      label: "Static Chromatic Colors",
     },
     hueAnimationAmplitude: {
       value: 15,

--- a/src/services/StrudelNotation.ts
+++ b/src/services/StrudelNotation.ts
@@ -9,6 +9,7 @@
  */
 
 import type { LogNote } from "@/types/patterns";
+import type { MusicalMode } from "@/types/music";
 
 export interface StrudelConfig {
   /** Playback tempo in BPM. @default 120 */
@@ -24,7 +25,7 @@ export interface StrudelConfig {
   /** Optional scale key override for relative notation. */
   scaleKey?: string;
   /** Optional scale mode override for relative notation. */
-  scaleMode?: string;
+  scaleMode?: MusicalMode;
 }
 
 const DEFAULT_CONFIG: StrudelConfig = {

--- a/src/services/music.ts
+++ b/src/services/music.ts
@@ -1,32 +1,23 @@
 // Music Theory Service for Emotitone Solfege
-// Handles all music theory calculations, scales, and emotional mappings
+// Handles all music theory calculations, scales, and interval-driven identities.
 
 import {
   CHROMATIC_NOTES,
   MAJOR_SCALE,
   MINOR_SCALE,
+  SCALE_MAP,
+  getModeDefinition,
+  getScaleForMode,
   type SolfegeData,
   type Scale,
 } from "@/data";
-import type {
-  Note,
-  MusicalMode,
-  ChromaticNote,
-} from "@/types/music";
+import type { ChromaticNote, ModeDefinition, MusicalMode, Note } from "@/types/music";
 import { Note as TonalNote, Scale as TonalScale } from "@tonaljs/tonal";
 
-// Re-export types for backward compatibility
-export type {
-  SolfegeData,
-  Scale,
-  Note,
-  MusicalMode,
-};
+export type { ChromaticNote, ModeDefinition, MusicalMode, Note, Scale, SolfegeData };
 
-// Re-export the imported constants for backward compatibility
-export { CHROMATIC_NOTES, MAJOR_SCALE, MINOR_SCALE };
+export { CHROMATIC_NOTES, MAJOR_SCALE, MINOR_SCALE, SCALE_MAP };
 
-// Add flat to sharp conversion map and edge case handling
 const FLAT_TO_SHARP_MAP: Record<string, ChromaticNote> = {
   Db: "C#",
   Eb: "D#",
@@ -63,56 +54,57 @@ export class MusicTheoryService {
   private currentKey: ChromaticNote = "C";
   private currentMode: MusicalMode = "major";
 
-  // Get the current key
   getCurrentKey(): string {
     return this.currentKey;
   }
 
-  // Set the current key
   setCurrentKey(key: ChromaticNote): void {
-    if (CHROMATIC_NOTES.includes(key)) {
-      this.currentKey = key;
-    } else {
+    if (!CHROMATIC_NOTES.includes(key)) {
       throw new Error(`Invalid key: ${key}`);
     }
+
+    this.currentKey = key;
   }
 
-  // Get the current mode
   getCurrentMode(): MusicalMode {
     return this.currentMode;
   }
 
-  // Set the current mode
   setCurrentMode(mode: MusicalMode): void {
     this.currentMode = mode;
   }
 
-  // Get the current scale
-  getCurrentScale(): Scale {
-    return this.currentMode === "major" ? MAJOR_SCALE : MINOR_SCALE;
+  getCurrentModeDefinition(): ModeDefinition {
+    return getModeDefinition(this.currentMode);
   }
 
-  // Helper function to convert flat notes to sharp notes
+  getCurrentScale(): Scale {
+    return getScaleForMode(this.currentMode);
+  }
+
+  getCurrentScaleDegreeCount(): number {
+    return this.getCurrentScale().degreeCount;
+  }
+
+  getCurrentScaleSemitoneOffsets(): number[] {
+    return this.getCurrentScale().intervals;
+  }
+
   private normalizeToSharp(note: string): ChromaticNote {
-    // Remove any octave numbers that might be present
     const baseNote = note.replace(/\d/g, "");
 
-    // Check double accidentals first (F## -> G, Gbb -> F)
     if (DOUBLE_ACCIDENTAL_MAP[baseNote]) {
       return DOUBLE_ACCIDENTAL_MAP[baseNote];
     }
 
-    // Check single accidental edge cases (E# -> F, B# -> C)
     if (EDGE_CASE_MAP[baseNote]) {
       return EDGE_CASE_MAP[baseNote];
     }
 
-    // If it's already a valid note, return it
     if (CHROMATIC_NOTES.includes(baseNote as ChromaticNote)) {
       return baseNote as ChromaticNote;
     }
 
-    // Convert flat to sharp if it exists in our map
     const sharpVersion = FLAT_TO_SHARP_MAP[baseNote];
     if (sharpVersion) {
       return sharpVersion;
@@ -121,30 +113,90 @@ export class MusicTheoryService {
     throw new Error(`Unable to normalize note: ${note}`);
   }
 
-  // Update getCurrentScaleNotes to use the new normalizeToSharp function
-  getCurrentScaleNotes(): ChromaticNote[] {
-    const scaleName = this.currentMode === "major" ? "major" : "minor";
-    const scaleNotes = TonalScale.get(`${this.currentKey} ${scaleName}`).notes;
-
-    // Ensure we have 7 notes and normalize them to sharps
-    return scaleNotes.slice(0, 7).map((note) => {
-      try {
-        return this.normalizeToSharp(note);
-      } catch (error) {
-        // If normalization fails, try direct conversion from Tonal.js note
-        const tonalNote = TonalNote.get(note);
-        if (
-          tonalNote.pc &&
-          CHROMATIC_NOTES.includes(tonalNote.pc as ChromaticNote)
-        ) {
-          return tonalNote.pc as ChromaticNote;
-        }
-        throw new Error(`Invalid note ${note} returned by Tonal.js`);
+  private normalizeScaleNote(note: string): ChromaticNote {
+    try {
+      return this.normalizeToSharp(note);
+    } catch {
+      const tonalNote = TonalNote.get(note);
+      if (
+        tonalNote.pc &&
+        CHROMATIC_NOTES.includes(tonalNote.pc as ChromaticNote)
+      ) {
+        return tonalNote.pc as ChromaticNote;
       }
-    });
+
+      throw new Error(`Invalid note ${note} returned by Tonal.js`);
+    }
   }
 
-  // Calculate the correct octave for a note to ensure ascending scale order
+  getCurrentScaleNotes(): ChromaticNote[] {
+    const currentScale = this.getCurrentScale();
+    const scaleNotes = TonalScale.get(
+      `${this.currentKey} ${currentScale.tonalName}`
+    ).notes;
+
+    if (!scaleNotes.length) {
+      return currentScale.intervalNames.map((_, index) => {
+        const semitoneOffset = currentScale.intervals[index] ?? 0;
+        const noteIndex =
+          (CHROMATIC_NOTES.indexOf(this.currentKey) + semitoneOffset) % 12;
+        return CHROMATIC_NOTES[noteIndex];
+      });
+    }
+
+    return scaleNotes.map((note) => this.normalizeScaleNote(note));
+  }
+
+  getChromaticNoteForScaleIndex(scaleIndex: number): ChromaticNote | null {
+    const scaleNotes = this.getCurrentScaleNotes();
+    return scaleNotes[scaleIndex] ?? null;
+  }
+
+  private getRelativeSemitoneFromKey(noteName: ChromaticNote): number {
+    const keyIndex = CHROMATIC_NOTES.indexOf(this.currentKey);
+    const noteIndex = CHROMATIC_NOTES.indexOf(noteName);
+
+    if (keyIndex === -1 || noteIndex === -1) {
+      return -1;
+    }
+
+    return (noteIndex - keyIndex + 12) % 12;
+  }
+
+  getScaleIndexForChromaticNote(noteName: string): number | null {
+    let chromaticNote: ChromaticNote;
+
+    try {
+      chromaticNote = this.normalizeToSharp(noteName);
+    } catch {
+      return null;
+    }
+
+    const scaleNotes = this.getCurrentScaleNotes();
+    const exactIndex = scaleNotes.indexOf(chromaticNote);
+    if (exactIndex !== -1) {
+      return exactIndex;
+    }
+
+    const relativeSemitone = this.getRelativeSemitoneFromKey(chromaticNote);
+    if (relativeSemitone === -1) {
+      return null;
+    }
+
+    const scaleIntervals = this.getCurrentScaleSemitoneOffsets();
+    let fallbackIndex = 0;
+
+    for (let index = 0; index < scaleIntervals.length; index++) {
+      if (scaleIntervals[index] <= relativeSemitone) {
+        fallbackIndex = index;
+      } else {
+        break;
+      }
+    }
+
+    return fallbackIndex;
+  }
+
   private calculateCorrectOctave(
     noteName: ChromaticNote,
     rootKey: ChromaticNote,
@@ -153,35 +205,29 @@ export class MusicTheoryService {
     const noteIndex = CHROMATIC_NOTES.indexOf(noteName);
     const rootIndex = CHROMATIC_NOTES.indexOf(rootKey);
 
-    // If the note comes before the root in the chromatic sequence, it needs to be in the next octave
-    if (noteIndex < rootIndex) {
-      return baseOctave + 1;
-    }
-
-    return baseOctave;
+    return noteIndex < rootIndex ? baseOctave + 1 : baseOctave;
   }
 
-  // Update getNoteFrequency to use normalizeToSharp
   getNoteFrequency(solfegeIndex: number, octave: number = 4): number {
     const scaleNotes = this.getCurrentScaleNotes();
-    const noteName = scaleNotes[solfegeIndex] as ChromaticNote;
+    const scaleLength = scaleNotes.length;
 
-    // Handle octave note (Do') - use the root note but one octave higher
     let actualOctave = octave;
-    let actualNoteName = noteName;
+    let actualNoteName = scaleNotes[solfegeIndex];
 
-    if (solfegeIndex === 7) {
+    if (solfegeIndex === scaleLength) {
       actualOctave = octave + 1;
-      actualNoteName = scaleNotes[0] as ChromaticNote;
-    } else {
+      actualNoteName = scaleNotes[0];
+    } else if (actualNoteName) {
       actualOctave = this.calculateCorrectOctave(
         actualNoteName,
         this.currentKey,
         octave
       );
+    } else {
+      actualNoteName = scaleNotes[0] ?? this.currentKey;
     }
 
-    // Use Tonal.js for accurate frequency calculation
     const noteWithOctave = `${actualNoteName}${actualOctave}`;
     const tonalNote = TonalNote.get(noteWithOctave);
 
@@ -189,7 +235,6 @@ export class MusicTheoryService {
       return tonalNote.freq;
     }
 
-    // Fallback calculation remains the same
     const noteIndex = CHROMATIC_NOTES.indexOf(actualNoteName);
     const A4_INDEX = 9;
     const A4_FREQUENCY = 440;
@@ -197,35 +242,32 @@ export class MusicTheoryService {
     return A4_FREQUENCY * Math.pow(2, semitonesFromA4 / 12);
   }
 
-  // Update getNoteName to use normalizeToSharp
   getNoteName(solfegeIndex: number, octave: number = 4): string {
     const scaleNotes = this.getCurrentScaleNotes();
-    const noteName = scaleNotes[solfegeIndex];
+    const scaleLength = scaleNotes.length;
 
     let actualOctave = octave;
-    let actualNoteName = noteName;
+    let actualNoteName = scaleNotes[solfegeIndex];
 
-    if (solfegeIndex === 7) {
+    if (solfegeIndex === scaleLength) {
       actualOctave = octave + 1;
       actualNoteName = scaleNotes[0];
-    } else {
+    } else if (actualNoteName) {
       actualOctave = this.calculateCorrectOctave(
         actualNoteName,
         this.currentKey,
         octave
       );
+    } else {
+      actualNoteName = scaleNotes[0] ?? this.currentKey;
     }
 
     return `${actualNoteName}${actualOctave}`;
   }
 
-  // Get solfege data for a specific degree
   getSolfegeData(degree: number): SolfegeData | null {
-    const scale = this.getCurrentScale();
-    return scale.solfege[degree] || null;
+    return this.getCurrentScale().solfege[degree] || null;
   }
-
 }
 
-// Export a singleton instance
 export const musicTheory = new MusicTheoryService();

--- a/src/services/superdoughAudio.ts
+++ b/src/services/superdoughAudio.ts
@@ -59,6 +59,8 @@ const _activeStrudelVisuals = new Map<
     noteName: string;
     frequency: number;
     octave: number;
+    mode: string;
+    key: ChromaticNote;
     instrument: string;
     releaseTimeout: number;
   }
@@ -269,21 +271,7 @@ function resolveSolfegeIndex(noteName: string): number | null {
     return null;
   }
 
-  const scaleNotes = musicTheory.getCurrentScaleNotes();
-  const directIndex = scaleNotes.indexOf(chromaticNote);
-  if (directIndex !== -1) {
-    return directIndex;
-  }
-
-  const keyIndex = CHROMATIC_NOTES.indexOf(
-    musicTheory.getCurrentKey() as ChromaticNote
-  );
-  const chromaticIndex = CHROMATIC_NOTES.indexOf(chromaticNote);
-  if (keyIndex === -1 || chromaticIndex === -1) {
-    return null;
-  }
-
-  return Math.floor(((chromaticIndex - keyIndex + 12) % 12) / 2);
+  return musicTheory.getScaleIndexForChromaticNote(chromaticNote);
 }
 
 function extractHapNoteName(hap: unknown): string | null {
@@ -343,6 +331,8 @@ function buildStrudelVisualPayload(hap: unknown) {
       noteName: parsedNote.name,
       octave: parsedNote.oct,
       frequency: extractHapFrequency(hap, noteValue),
+      mode: musicTheory.getCurrentMode(),
+      key: musicTheory.getCurrentKey() as ChromaticNote,
       instrument:
         typeof (hap as { value?: { s?: unknown } })?.value?.s === "string"
           ? String((hap as { value?: { s?: unknown } }).value?.s)
@@ -368,6 +358,8 @@ function releaseStrudelVisual(noteId: string) {
         noteName: active.noteName,
         frequency: active.frequency,
         octave: active.octave,
+        mode: active.mode,
+        key: active.key,
         instrument: active.instrument,
         instrumentConfig: null,
         source: STRUDEL_PLAYBACK_SOURCE,
@@ -409,6 +401,8 @@ export async function emotitoneStrudelOutput(
       noteName: visualPayload.noteName,
       frequency: visualPayload.frequency,
       octave: visualPayload.octave,
+      mode: visualPayload.mode,
+      key: visualPayload.key,
       instrument: visualPayload.instrument,
       releaseTimeout,
     });
@@ -422,6 +416,8 @@ export async function emotitoneStrudelOutput(
           octave: visualPayload.octave,
           noteId,
           noteName: visualPayload.noteName,
+          mode: visualPayload.mode,
+          key: visualPayload.key,
           instrument: visualPayload.instrument,
           instrumentConfig: null,
           durationMs,

--- a/src/stores/music.ts
+++ b/src/stores/music.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref, computed, readonly, watch } from "vue";
-import { musicTheory, CHROMATIC_NOTES } from "@/services/music";
+import { musicTheory } from "@/services/music";
+import { getModeDefinition } from "@/data";
 import type {
   SolfegeData,
   MusicalMode,
@@ -9,11 +10,6 @@ import type {
 } from "@/types/music";
 import * as superdoughAudio from "@/services/superdoughAudio";
 import { useInstrumentStore } from "@/stores/instrument";
-import {
-  MAJOR_SOLFEGE,
-  MINOR_SOLFEGE,
-  type Scale,
-} from "@/data";
 
 // Type for note input - either a chromatic note with octave or solfege index
 type NoteInput = string | { solfegeIndex: number; octave: number };
@@ -53,7 +49,17 @@ export const useMusicStore = defineStore(
     const sequence = ref<string[]>([]);
 
     // Getters
-    const currentScale = computed(() => musicTheory.getCurrentScale());
+    const currentScale = computed(() => {
+      // Bind the singleton service to reactive store state so downstream
+      // consumers like the keyboard and visual systems actually refresh
+      // when mode or key changes after initial mount.
+      musicTheory.setCurrentKey(currentKey.value as ChromaticNote);
+      musicTheory.setCurrentMode(currentMode.value);
+      return musicTheory.getCurrentScale();
+    });
+    const currentModeDefinition = computed(() =>
+      getModeDefinition(currentMode.value)
+    );
 
     const currentScaleNotes = computed(() => {
       musicTheory.setCurrentKey(currentKey.value as ChromaticNote);
@@ -67,10 +73,15 @@ export const useMusicStore = defineStore(
     });
 
     const currentKeyDisplay = computed(() => {
-      return `${currentKey.value} ${
-        currentMode.value.charAt(0).toUpperCase() + currentMode.value.slice(1)
-      }`;
+      return `${currentKey.value} ${currentModeDefinition.value.label}`;
     });
+
+    function getCurrentNoteContext() {
+      return {
+        mode: currentMode.value,
+        key: currentKey.value as ChromaticNote,
+      };
+    }
 
     // Melody-related getters (removed)
 
@@ -79,46 +90,12 @@ export const useMusicStore = defineStore(
       note: NoteInput
     ): { solfegeIndex: number; octave: number } | null {
       if (typeof note === "string") {
-        // Handle chromatic note with octave (e.g., "C4", "F#5")
         const noteName = note.slice(0, -1);
         const octave = parseInt(note.slice(-1));
-
-        // Get current scale notes
-        const scaleNotes = currentScaleNotes.value;
-
-        // Try to find exact match in scale
-        const noteInScale = scaleNotes.find((n) => {
-          const normalizedNote = n.replace("#", "").replace("b", "");
-          const normalizedInput = noteName.replace("#", "").replace("b", "");
-          return normalizedNote === normalizedInput;
-        });
-
-        if (noteInScale) {
-          return {
-            solfegeIndex: scaleNotes.indexOf(noteInScale),
-            octave,
-          };
-        }
-
-        // If not in scale, find closest scale degree
-        const chromaticIndex = CHROMATIC_NOTES.indexOf(
-          noteName as ChromaticNote
-        );
-        if (chromaticIndex !== -1) {
-          const keyIndex = CHROMATIC_NOTES.indexOf(
-            currentKey.value as ChromaticNote
-          );
-          const relativeIndex = (chromaticIndex - keyIndex + 12) % 12;
-          return {
-            solfegeIndex: Math.floor(relativeIndex / 2),
-            octave,
-          };
-        }
-
-        return null;
+        const solfegeIndex = musicTheory.getScaleIndexForChromaticNote(noteName);
+        return solfegeIndex === null ? null : { solfegeIndex, octave };
       }
 
-      // Already in solfege index format
       return note;
     }
 
@@ -128,38 +105,8 @@ export const useMusicStore = defineStore(
     ): { solfegeIndex: number; octave: number } | null {
       const noteName = note.slice(0, -1) as ChromaticNote;
       const octave = parseInt(note.slice(-1));
-
-      // Get current scale notes
-      const scaleNotes = currentScaleNotes.value;
-
-      // Try to find exact match in scale
-      const noteInScale = scaleNotes.find((n) => {
-        const normalizedNote = n.replace("#", "").replace("b", "");
-        const normalizedInput = noteName.replace("#", "").replace("b", "");
-        return normalizedNote === normalizedInput;
-      });
-
-      if (noteInScale) {
-        return {
-          solfegeIndex: scaleNotes.indexOf(noteInScale),
-          octave,
-        };
-      }
-
-      // If not in scale, find closest scale degree
-      const chromaticIndex = CHROMATIC_NOTES.indexOf(noteName);
-      if (chromaticIndex !== -1) {
-        const keyIndex = CHROMATIC_NOTES.indexOf(
-          currentKey.value as ChromaticNote
-        );
-        const relativeIndex = (chromaticIndex - keyIndex + 12) % 12;
-        return {
-          solfegeIndex: Math.floor(relativeIndex / 2),
-          octave,
-        };
-      }
-
-      return null;
+      const solfegeIndex = musicTheory.getScaleIndexForChromaticNote(noteName);
+      return solfegeIndex === null ? null : { solfegeIndex, octave };
     }
 
     // Actions
@@ -208,6 +155,7 @@ export const useMusicStore = defineStore(
 
       const solfege = solfegeData.value[solfegeIndex];
       if (solfege) {
+        const noteContext = getCurrentNoteContext();
         currentNote.value = solfege.name;
         isPlaying.value = true;
 
@@ -230,6 +178,7 @@ export const useMusicStore = defineStore(
             noteName,
             solfegeIndex,
             octave: finalOctave,
+            ...noteContext,
             instrument: instrumentStore.currentInstrument,
             instrumentConfig: null,
           },
@@ -265,6 +214,7 @@ export const useMusicStore = defineStore(
 
       const solfege = solfegeData.value[solfegeIndex];
       if (solfege) {
+        const noteContext = getCurrentNoteContext();
         const frequency = musicTheory.getNoteFrequency(
           solfegeIndex,
           finalOctave
@@ -290,6 +240,7 @@ export const useMusicStore = defineStore(
             octave: finalOctave,
             noteId,
             noteName,
+            ...noteContext,
           };
 
           activeNotes.value.set(noteId, activeNote);
@@ -304,6 +255,7 @@ export const useMusicStore = defineStore(
               octave: finalOctave,
               noteId,
               noteName,
+              ...noteContext,
               instrument: instrumentStore.currentInstrument,
               instrumentConfig: null,
             },
@@ -350,6 +302,7 @@ export const useMusicStore = defineStore(
 
       const solfege = solfegeData.value[solfegeIndex];
       if (solfege) {
+        const noteContext = getCurrentNoteContext();
         const noteName = musicTheory.getNoteName(solfegeIndex, finalOctave);
         const frequency = musicTheory.getNoteFrequency(
           solfegeIndex,
@@ -377,6 +330,7 @@ export const useMusicStore = defineStore(
             octave: finalOctave,
             duration,
             time,
+            ...noteContext,
             instrument: instrumentToReport,
             instrumentConfig: null,
             sequencerInstrument: instrument,
@@ -456,6 +410,8 @@ export const useMusicStore = defineStore(
               noteName: activeNote.noteName,
               frequency: activeNote.frequency,
               octave: activeNote.octave,
+              mode: activeNote.mode,
+              key: activeNote.key,
               instrument: instrumentStore.currentInstrument,
               instrumentConfig: null,
             },
@@ -487,6 +443,8 @@ export const useMusicStore = defineStore(
               noteName: activeNote.noteName,
               frequency: activeNote.frequency,
               octave: activeNote.octave,
+              mode: activeNote.mode,
+              key: activeNote.key,
               instrument: instrumentStore.currentInstrument,
               instrumentConfig: null,
             },
@@ -573,6 +531,7 @@ export const useMusicStore = defineStore(
 
       // Getters
       currentScale,
+      currentModeDefinition,
       currentScaleNotes,
       solfegeData,
       currentKeyDisplay,

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -3,7 +3,7 @@
  * Type definitions for canvas rendering, particles, and animation systems
  */
 
-import type { SolfegeData } from "./music";
+import type { ChromaticNote, MusicalMode, SolfegeData } from "./music";
 
 /**
  * Active blob state for canvas rendering
@@ -35,6 +35,12 @@ export interface ActiveBlob {
   vibrationPhase: number;
   /** Current scale multiplier for grow/shrink animations */
   scale: number;
+  /** Harmonic context snapshot used for stable color rendering */
+  mode: MusicalMode;
+  /** Key snapshot used for stable color rendering */
+  key: ChromaticNote;
+  /** Octave snapshot used for scale-relative lightness */
+  octave: number;
 }
 
 /**
@@ -141,6 +147,10 @@ export interface CanvasNoteEvent {
   frequency: number;
   /** Solfege index */
   solfegeIndex: number;
+  /** Harmonic mode snapshot */
+  mode?: MusicalMode;
+  /** Key snapshot */
+  key?: ChromaticNote;
   /** Whether note is currently playing */
   isPlaying?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,9 @@ export type {
   SolfegeData,
   Scale,
   Note,
+  ModeDefinition,
   MusicalMode,
+  MusicalModeFamily,
   ChromaticNote,
   ActiveNote,
 } from "./music";

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -4,13 +4,22 @@
  */
 
 /**
+ * Musical mode families used for UI grouping and keyboard behavior
+ */
+export type MusicalModeFamily =
+  | "heptatonic"
+  | "hexatonic"
+  | "pentatonic"
+  | "chromatic";
+
+/**
  * Core solfege note data structure with emotional and visual properties
  * Colors are now handled by the unified color system and not stored in the data structure
  */
 export interface SolfegeData {
   /** Solfege name (Do, Re, Mi, etc.) */
   name: string;
-  /** Scale degree number (1-8) */
+  /** Scale degree number within the current mode (1-based) */
   number: number;
   /** Emotional character description */
   emotion: string;
@@ -20,14 +29,58 @@ export interface SolfegeData {
   fleckShape: "circle" | "star" | "diamond" | "sparkle" | "mist";
   /** Textural description for visual effects */
   texture: string;
+  /** Tonal interval name from the tonic (for example 3m or 5P) */
+  intervalName?: string;
+  /** Semitone offset from the tonic */
+  semitones?: number;
 }
 
 /**
- * Musical scale definition with intervals and solfege data
+ * Supported musical modes
+ */
+export type MusicalMode =
+  | "major"
+  | "minor"
+  | "dorian"
+  | "phrygian"
+  | "lydian"
+  | "mixolydian"
+  | "locrian"
+  | "harmonic minor"
+  | "melodic minor"
+  | "major pentatonic"
+  | "minor pentatonic"
+  | "major blues"
+  | "minor blues"
+  | "chromatic";
+
+/**
+ * Central mode catalog entry
+ */
+export interface ModeDefinition {
+  mode: MusicalMode;
+  label: string;
+  tonalName: string;
+  family: MusicalModeFamily;
+  degreeCount: number;
+}
+
+/**
+ * Musical scale definition with generated intervals and solfege data
  */
 export interface Scale {
-  /** Scale name (Major, Minor, etc.) */
+  /** Display name (Major, Dorian, etc.) */
   name: string;
+  /** Application mode id */
+  mode: MusicalMode;
+  /** Tonal.js scale name */
+  tonalName: string;
+  /** Mode family */
+  family: MusicalModeFamily;
+  /** Number of scale degrees before the octave */
+  degreeCount: number;
+  /** Tonal interval names from the tonic */
+  intervalNames: string[];
   /** Semitone intervals from root note */
   intervals: number[];
   /** Associated solfege data for each scale degree */
@@ -58,11 +111,6 @@ export interface Note {
   /** MIDI note number */
   midiNumber: number;
 }
-
-/**
- * Musical mode type
- */
-export type MusicalMode = "major" | "minor";
 
 /**
  * Chromatic note names
@@ -97,4 +145,8 @@ export interface ActiveNote {
   noteId: string;
   /** Note name with octave (e.g., "C4", "E5") */
   noteName: string;
+  /** Harmonic context snapshot for downstream visuals */
+  mode: MusicalMode;
+  /** Key snapshot for downstream visuals */
+  key: ChromaticNote;
 }

--- a/src/types/visual.ts
+++ b/src/types/visual.ts
@@ -199,17 +199,17 @@ export interface BlobConfig {
 export interface AmbientConfig {
   /** Whether ambient effects are enabled */
   isEnabled: boolean;
-  /** Opacity for major scale notes */
+  /** Legacy field retained for compatibility; now controls tonic/center opacity */
   opacityMajor: number;
-  /** Opacity for minor scale notes */
+  /** Legacy field retained for compatibility; now controls accent opacity */
   opacityMinor: number;
-  /** Brightness for major scale notes */
+  /** Legacy field retained for compatibility; now controls tonic brightness */
   brightnessMajor: number;
-  /** Brightness for minor scale notes */
+  /** Legacy field retained for compatibility; now controls accent brightness */
   brightnessMinor: number;
-  /** Saturation for major scale notes */
+  /** Legacy field retained for compatibility; now controls tonic saturation */
   saturationMajor: number;
-  /** Saturation for minor scale notes */
+  /** Legacy field retained for compatibility; now controls accent saturation */
   saturationMinor: number;
 }
 


### PR DESCRIPTION
## Summary
- add a centralized Tonal-backed catalog for 14 supported modes and generate scale identities from intervals
- update the keyboard, colors, pattern labels, and playback highlighting to respect variable degree counts
- propagate mode/key context into the visual systems so blobs, strings, popup, and ambient rendering stay stable across mode changes

## Verification
- `bun run type-check`
- `bunx vitest run src/__tests__/stores/music.test.ts src/__tests__/services/music.test.ts src/__tests__/composables/useColorSystem.test.ts src/__tests__/composables/useKeyboardControls.test.ts`